### PR TITLE
Fix test expectations for tabula.mappaValores/mappaClaves C++ target

### DIFF
--- a/fons/proba/norma/tabula.yaml
+++ b/fons/proba/norma/tabula.yaml
@@ -320,8 +320,6 @@
   source: |
       fixum tabula<textus, numerus> map = {}
       map.mappaValores(pro v: v * 2)
-  cpp:
-      - '[...map].map(([k, v]) => [k, '
   ts:
       - '[...map].map(([k, v]) => [k, '
   rs:
@@ -329,16 +327,13 @@
   fab:
       - 'fixum tabula<textus, numerus> map = {}'
       - 'map.mappaValores(pro v: v * 2)'
-  skip: [zig, rs, py]
+  skip: [zig, rs, py, cpp]
 
 # mappaClaves transforms keys
 - name: 'mappaClaves -> transform keys'
   source: |
       fixum tabula<textus, numerus> map = {}
       map.mappaClaves(pro k: k + "_new")
-  cpp:
-      - '[...map].map(([k, v]) => ['
-      - ', v])'
   ts:
       - '[...map].map(([k, v]) => ['
       - ', v])'
@@ -347,7 +342,7 @@
   fab:
       - 'fixum tabula<textus, numerus> map = {}'
       - 'map.mappaClaves(pro k: k + "_new")'
-  skip: [zig, rs, py]
+  skip: [zig, rs, py, cpp]
 
 # inObjectum converts to plain object (JS/Python only)
 - name: 'inObjectum -> object from map'


### PR DESCRIPTION
## Summary

- Removed incorrect JavaScript syntax from C++ test expectations for `mappaValores` and `mappaClaves`
- Added `cpp` to skip list for both test cases, aligning with how Zig is handled

## Context

Issue #9 identified that test expectations in `fons/proba/norma/tabula.yaml` contained JavaScript syntax (`[...map].map(([k, v]) => ...`) for the C++ target, but the norma file (`fons/norma/tabula.fab`) lacks `@ verte cpp` annotations for these methods.

Without C++ translations, these methods cannot be properly compiled to C++, so tests should skip the C++ target just like they skip Zig (which also lacks implementations).

## Changes

- `fons/proba/norma/tabula.yaml`:
  - Removed `cpp:` test expectations containing JavaScript syntax
  - Updated skip lists: `skip: [zig, rs, py, cpp]`

## Test plan

- [x] `bun test -t "mappaValores"` passes
- [x] `bun test -t "mappaClaves"` passes

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)