### PR TITLE
Fix: Skip stdlib check for user-defined genus methods

### DIFF
--- a/fons/faber/codegen/cpp/expressions/call.ts
+++ b/fons/faber/codegen/cpp/expressions/call.ts
@@ -126,6 +126,13 @@ export function genCallExpression(node: CallExpression, g: CppGenerator): string
         const objType = node.callee.object.resolvedType;
         const collectionName = objType?.kind === 'generic' ? objType.name : null;
 
+        // WHY: Skip stdlib check entirely for user-defined types. User genus methods
+        // should never match stdlib collections, even if method names coincide.
+        if (objType?.kind === 'user') {
+            // Pass through to normal method call emission below
+            return `${obj}.${methodName}(${args})`;
+        }
+
         // Try norma registry for the resolved collection type
         if (collectionName) {
             // WHY: Validate morphology before translation. Catches undefined forms.

--- a/fons/faber/codegen/py/expressions/call.ts
+++ b/fons/faber/codegen/py/expressions/call.ts
@@ -101,6 +101,13 @@ export function genCallExpression(node: CallExpression, g: PyGenerator): string 
         const objType = node.callee.object.resolvedType;
         const collectionName = objType?.kind === 'generic' ? objType.name : null;
 
+        // WHY: Skip stdlib check entirely for user-defined types. User genus methods
+        // should never match stdlib collections, even if method names coincide.
+        if (objType?.kind === 'user') {
+            // Pass through to normal method call emission below
+            return `${obj}.${methodName}(${args})`;
+        }
+
         // Try norma registry for the resolved collection type
         if (collectionName) {
             // WHY: Validate morphology before translation. Catches undefined forms.

--- a/fons/faber/codegen/rs/expressions/call.ts
+++ b/fons/faber/codegen/rs/expressions/call.ts
@@ -93,6 +93,13 @@ export function genCallExpression(node: CallExpression, g: RsGenerator): string 
         const objType = node.callee.object.resolvedType;
         const collectionName = objType?.kind === 'generic' ? objType.name : null;
 
+        // WHY: Skip stdlib check entirely for user-defined types. User genus methods
+        // should never match stdlib collections, even if method names coincide.
+        if (objType?.kind === 'user') {
+            // Pass through to normal method call emission below
+            return `${obj}.${methodName}(${args})`;
+        }
+
         // Try norma registry for the resolved collection type
         if (collectionName) {
             // WHY: Validate morphology before translation. Catches undefined forms.

--- a/fons/faber/codegen/ts/expressions/call.ts
+++ b/fons/faber/codegen/ts/expressions/call.ts
@@ -115,6 +115,13 @@ export function genCallExpression(node: CallExpression, g: TsGenerator): string 
         const collectionName = objType?.kind === 'generic' ? objType.name :
                                objType?.kind === 'primitive' ? objType.name : null;
 
+        // WHY: Skip stdlib check entirely for user-defined types. User genus methods
+        // should never match stdlib collections, even if method names coincide.
+        if (objType?.kind === 'user') {
+            // Pass through to normal method call emission below
+            return `${obj}.${methodName}(${args})`;
+        }
+
         // STRICT: No fallback guessing. If this method name is known to norma
         // for receiver types but we can't resolve the receiver type, emit an
         // actionable compiler error.

--- a/fons/faber/codegen/zig/expressions/call.ts
+++ b/fons/faber/codegen/zig/expressions/call.ts
@@ -90,6 +90,13 @@ export function genCallExpression(node: CallExpression, g: ZigGenerator): string
         const objType = node.callee.object.resolvedType;
         const collectionName = objType?.kind === 'generic' ? objType.name : null;
 
+        // WHY: Skip stdlib check entirely for user-defined types. User genus methods
+        // should never match stdlib collections, even if method names coincide.
+        if (objType?.kind === 'user') {
+            // Pass through to normal method call emission below
+            return `${obj}.${methodName}(${args})`;
+        }
+
         // Helper to apply norma translation with allocator handling
         const applyZigNorma = (coll: string, method: string): string | null => {
             const norma = getNormaTranslation('zig', coll, method);


### PR DESCRIPTION
## Summary

- Fixes #6: User-defined genus methods no longer incorrectly flagged as stdlib collisions
- Added early return for `objType?.kind === 'user'` in all target codegens (ts, cpp, rs, py, zig)
- Prevents false errors when user method names coincide with stdlib methods like `adde()`

## Test plan

- [x] Existing test now passes: `codegen/expressions/morphologia > @ts > morphologia ignores non-enabled receiver`
- [x] Manual compilation test with Calculator genus succeeds without errors
- [x] All morphologia tests still passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)