### PR TITLE
Fix morphology parser misclassifying single-vowel suffixes

### DIFF
--- a/fons/faber/codegen/norma-registry.test.ts
+++ b/fons/faber/codegen/norma-registry.test.ts
@@ -81,6 +81,16 @@ describe('norma-registry', () => {
 
                 expect(result.valid).toBe(true);
             });
+
+            test('selecta is valid (perfectum declared, stem select)', () => {
+                // WHY: Regression test for issue #5. The method 'selecta' with stem 'select'
+                // was being misclassified as imperativus (suffix 'a') instead of perfectum
+                // (suffix 'ta'). The greedy parser correctly identifies '-ta' as perfectum.
+                const result = validateMorphology('tabula', 'selecta');
+
+                expect(result.valid).toBe(true);
+                expect(result.error).toBeUndefined();
+            });
         });
 
         describe('invalid method calls', () => {


### PR DESCRIPTION
## Summary

- Fixed stem-guided morphology parser incorrectly classifying `selecta` as `imperativus` instead of `perfectum`
- Implemented disambiguation logic: when stem-guided parser returns undeclared form, check if greedy parser gives declared form
- Added regression test for `selecta` with stem `select`

## Root Cause

For `selecta` with declared stem `select`:
1. Stem-guided parser: `'select' + 'a'` → `imperativus` (wrong)
2. Greedy parser: `'selec' + 'ta'` → `perfectum` (correct)

The single-vowel suffix `'a'` was matched as imperative instead of recognizing `-ta` as the perfectum participle suffix.

## Solution

Uses Approach C from issue #5: When stem-guided parser returns an undeclared form, fallback to greedy parser if it returns a declared form. Override the stem to match the declared stem for validation consistency.

## Test Results

Before fix:
- `selecta` tests failing with morphology error
- 4009 tests passing

After fix:
- `selecta` tests passing (ts, cpp, rs)
- 4012 tests passing
- Added regression test case

Resolves #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)