### PR TITLE
Add sinistratum/dextratum bit shift keywords to rivus lexer

### DIFF
--- a/fons/rivus/ast/expressia.fab
+++ b/fons/rivus/ast/expressia.fab
@@ -163,6 +163,15 @@ discretio Expressia {
         Expressia alternans
     }
 
+    # Bit shift expression
+    # Examples: x dextratum 3 -> x >> 3, x sinistratum 3 -> x << 3
+    TranslatioExpressia {
+        Locus locus
+        Expressia expressia          # the value being shifted
+        textus directio              # "dextratum" | "sinistratum"
+        Expressia quantitas          # shift amount
+    }
+
     # Range expression for slicing and iteration
     # Examples: 1..10 (exclusive), 1 usque 10 (inclusive)
     AmbitusExpressia {

--- a/fons/rivus/ast/lexema.fab
+++ b/fons/rivus/ast/lexema.fab
@@ -243,6 +243,8 @@ ordo VerbumId {
     Nonnihil
     Negativum
     Positivum
+    Dextratum
+    Sinistratum
 
     # -------------------------------------------------------------------------
     # Literal Values

--- a/fons/rivus/codegen/ts/expressia/index.fab
+++ b/fons/rivus/codegen/ts/expressia/index.fab
@@ -440,6 +440,14 @@ functio genExpressia(Expressia expr, TsGenerator g) -> textus {
 
             redde scriptum("/* unknown conversion: § */", conv.signum)
         }
+
+        # Bit shift expression
+        casu TranslatioExpressia ut t {
+            fixum expr = genExpressia(t.expressia, g)
+            fixum amount = genExpressia(t.quantitas, g)
+            fixum op = (t.directio qua textus) == "dextratum" sic ">>" secus "<<"
+            redde scriptum("(§ § §)", expr, op, amount)
+        }
     }
 
     # Fallback - should not reach here

--- a/fons/rivus/lexicon/verba.fab
+++ b/fons/rivus/lexicon/verba.fab
@@ -136,6 +136,8 @@ functio verbumFaberId(textus v) -> VerbumId? {
         casu "nonnihil" reddit VerbumId.Nonnihil
         casu "negativum" reddit VerbumId.Negativum
         casu "positivum" reddit VerbumId.Positivum
+        casu "dextratum" reddit VerbumId.Dextratum
+        casu "sinistratum" reddit VerbumId.Sinistratum
 
         # ---- Literal Values ----
         casu "ego" reddit VerbumId.Ego

--- a/fons/rivus/parser/expressia/unaria.fab
+++ b/fons/rivus/parser/expressia/unaria.fab
@@ -395,6 +395,20 @@ functio parsePostfix(Resolvitor r) -> Expressia {
             perge
         }
 
+        # Bit shift: expr dextratum n, expr sinistratum n
+        si p.probaVerbum("dextratum") aut p.probaVerbum("sinistratum") {
+            fixum directio = p.procede().verbum
+            fixum quantitas = parseUnaria(r)
+
+            expressia = finge TranslatioExpressia {
+                locus: locus,
+                expressia: expressia,
+                directio: directio,
+                quantitas: quantitas
+            } qua Expressia
+            perge
+        }
+
         # No more postfix operators
         rumpe
     }


### PR DESCRIPTION
## Summary
- Adds `sinistratum` (left shift, `<<`) and `dextratum` (right shift, `>>`) keyword support to the rivus bootstrap compiler
- These keywords are Latin equivalents that the faber reference compiler already supports
- Enables rivus to compile Faber source code that uses bit shift operations

## Changes
- Add `Dextratum`/`Sinistratum` to `VerbumId` enum in `lexema.fab`
- Add keyword-to-enum mappings in `verba.fab`
- Add `TranslatioExpressia` AST type in `expressia.fab`
- Parse shift operators as postfix operators in `unaria.fab`
- Generate `>>` and `<<` operators in TS codegen

## Syntax
```faber
fixum a = 8 dextratum 2   # Compiles to: const a = 8 >> 2
fixum b = 1 sinistratum 4 # Compiles to: const b = 1 << 4
```

## Test plan
- [x] Verified faber compiler correctly compiles shift expressions
- [x] Verified rivus lexer recognizes the new keywords
- [x] Verified rivus parser creates TranslatioExpressia nodes
- [x] Verified rivus TS codegen generates correct `>>` and `<<` operators
- [x] Existing tests pass (pre-existing failures unrelated to this change)

Fixes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)