### PR TITLE
Fix non-exhaustive discerne statements with casu _ wildcards

### DIFF
--- a/fons/rivus/codegen/ts/expressia/ambitus.fab
+++ b/fons/rivus/codegen/ts/expressia/ambitus.fab
@@ -33,6 +33,7 @@ functio genAmbitusExpressia(Expressia expr, TsGenerator g) -> textus {
 
             redde scriptum("Array.from({length: § - §§}, (_, i) => § + i)", finis, initium, adj, initium)
         }
+        casu _ { }
     }
 
     redde genExpressia(expr, g)

--- a/fons/rivus/codegen/ts/expressia/index.fab
+++ b/fons/rivus/codegen/ts/expressia/index.fab
@@ -71,6 +71,7 @@ functio genExpressia(Expressia expr, TsGenerator g) -> textus {
                         fixum op = (r.inclusivum qua bivalens) sic "<=" secus "<"
                         redde scriptum("(§ >= § && § § §)", sinister, initium, sinister, op, finis)
                     }
+                    casu _ { }
                 }
                 redde scriptum("(§ intra §)", sinister, dexter)
             }
@@ -120,6 +121,7 @@ functio genExpressia(Expressia expr, TsGenerator g) -> textus {
                     casu EstExpressia ut est {
                         redde genEstExpressiaNegata(est.expressia, est.scopus qua TypusAnnotatio, g)
                     }
+                    casu _ { }
                 }
             }
 
@@ -153,6 +155,7 @@ functio genExpressia(Expressia expr, TsGenerator g) -> textus {
                         }
                     }
                 }
+                casu _ { }
             }
 
             # WHY: Avoid extra parens on RHS for assignments.
@@ -190,6 +193,7 @@ functio genExpressia(Expressia expr, TsGenerator g) -> textus {
                     g.exiProfundum()
                     redde scriptum("(() => {\n§\n§})()", body, g.ind())
                 }
+                casu _ { }
             }
             # Fallback: expression form.
             redde scriptum("(§)", genExpressia(e.corpus qua Expressia, g))
@@ -219,9 +223,11 @@ functio genExpressia(Expressia expr, TsGenerator g) -> textus {
                                         }
                                     }
                                 }
+                                casu _ { }
                             }
                         }
                     }
+                    casu _ { }
                 }
             }
 
@@ -237,6 +243,7 @@ functio genExpressia(Expressia expr, TsGenerator g) -> textus {
                     casu AmbitusExpressia ut a {
                         redde genSectioAccess(obj, a, e.optivum qua bivalens, e.nonNullum qua bivalens, g)
                     }
+                    casu _ { }
                 }
 
                 fixum idx = genNudaExpressia(e.proprietas, g)
@@ -381,6 +388,7 @@ functio genExpressia(Expressia expr, TsGenerator g) -> textus {
                     }
                     redde scriptum("(§)§ => {\n§\n§}", params.coniunge(", "), retType, body, g.ind())
                 }
+                casu _ { }
             }
             redde scriptum("(§)§ => §", params.coniunge(", "), retType, genExpressia(e.corpus qua Expressia, g))
         }
@@ -506,6 +514,8 @@ functio genPraefixumSententia(Sententia stmt, TsGenerator g) -> textus {
         casu ExpressiaSententia ut s {
             redde scriptum("§§;", g.ind(), genExpressia(s.expressia, g))
         }
+
+        casu _ { }
     }
 
     redde scriptum("§/* praefixum: unsupported statement */", g.ind())
@@ -546,6 +556,7 @@ functio invenitTabulaNomen(Expressia obiectum, TsGenerator g) -> textus? {
                 }
             }
         }
+        casu _ { }
     }
     redde nihil
 }
@@ -575,6 +586,7 @@ functio estNegativusIndex(Expressia expr) -> bivalens {
         casu UnariaExpressia ut u {
             redde (u.signum qua textus) == "-"
         }
+        casu _ { }
     }
     redde falsum
 }
@@ -615,6 +627,7 @@ functio genSectioAccess(textus obj, Expressia range, bivalens optivum, bivalens 
 
             redde scriptum("§.slice(§, §)", receiver, initium, finis)
         }
+        casu _ { }
     }
 
     redde scriptum("§[§]", obj, genExpressia(range, g))
@@ -635,9 +648,11 @@ functio legeNumerusLiteralis(Expressia expr) -> numerus? {
                             redde -legeNumerusTextus(l.crudus)
                         }
                     }
+                    casu _ { }
                 }
             }
         }
+        casu _ { }
     }
     redde nihil
 }
@@ -681,6 +696,7 @@ functio genNudaExpressia(Expressia expr, TsGenerator g) -> textus {
             }
             redde scriptum("§ § §", sin, signum, dex)
         }
+        casu _ { }
     }
 
     redde genExpressia(expr, g)

--- a/fons/rivus/codegen/ts/sententia/custodi.fab
+++ b/fons/rivus/codegen/ts/sententia/custodi.fab
@@ -27,6 +27,7 @@ functio genCustodi(lista<CustodiClausula> clausulae, TsGenerator g) -> textus {
                     vacuus = verum
                 }
             }
+            casu _ { }
         }
 
         si vacuus {
@@ -41,6 +42,7 @@ functio genCustodi(lista<CustodiClausula> clausulae, TsGenerator g) -> textus {
             casu MassaSententia ut m {
                 body = genMassa(m.corpus, g)
             }
+            casu _ { }
         }
         si body == "" {
             body = genSententia(clausula.consequens, g)

--- a/fons/rivus/codegen/ts/sententia/genus.fab
+++ b/fons/rivus/codegen/ts/sententia/genus.fab
@@ -73,6 +73,7 @@ functio genGenus(textus nomen, ignotum generaParametra, ignotum extendit, ignotu
                     estCreo = verum
                 }
             }
+            casu _ { }
         }
         si non estCreo {
             ceteri.adde(m)
@@ -142,6 +143,7 @@ functio genCreoMethod(Sententia creo, TsGenerator g) -> textus {
             }
             redde scriptum("§private creo() §", g.ind(), body)
         }
+        casu _ { }
     }
     redde scriptum("§private creo() {}", g.ind())
 }

--- a/fons/rivus/codegen/ts/sententia/iace.fab
+++ b/fons/rivus/codegen/ts/sententia/iace.fab
@@ -28,6 +28,7 @@ functio genIace(bivalens fatale, Expressia argumentum, TsGenerator g) -> textus 
                     redde scriptum("§throw new Panic(§);", g.ind(), expr)
                 }
             }
+            casu _ { }
         }
         redde scriptum("§throw new Panic(String(§));", g.ind(), expr)
     }
@@ -41,6 +42,7 @@ functio genIace(bivalens fatale, Expressia argumentum, TsGenerator g) -> textus 
                     message = expr
                 }
             }
+            casu _ { }
         }
         redde scriptum("§yield respond.error(\"EFAIL\", §);\n§return;", g.ind(), message, g.ind())
     }

--- a/fons/rivus/codegen/ts/sententia/in.fab
+++ b/fons/rivus/codegen/ts/sententia/in.fab
@@ -23,6 +23,7 @@ functio genIn(Expressia obiectum, Sententia corpus, TsGenerator g) -> textus {
             }
             redde lines.coniunge("\n")
         }
+        casu _ { }
     }
     redde genSententia(corpus, g)
 }
@@ -33,6 +34,7 @@ functio genInSententia(Sententia stmt, Expressia obiectum, TsGenerator g) -> tex
             fixum expr = genInExpressia(s.expressia, obiectum, g)
             redde scriptum("§§;", g.ind(), expr)
         }
+        casu _ { }
     }
     redde genSententia(stmt, g)
 }
@@ -45,8 +47,10 @@ functio genInExpressia(Expressia expr, Expressia obiectum, TsGenerator g) -> tex
                     fixum lhs = scriptum("§.§", genExpressia(obiectum, g), n.valor)
                     redde scriptum("§ § §", lhs, a.signum, genExpressia(a.dexter, g))
                 }
+                casu _ { }
             }
         }
+        casu _ { }
     }
     redde genExpressia(expr, g)
 }

--- a/fons/rivus/codegen/ts/sententia/iteratio.fab
+++ b/fons/rivus/codegen/ts/sententia/iteratio.fab
@@ -46,6 +46,7 @@ functio genIteratio(IteratioGenus species, textus variabilis, Expressia iterabil
 
             redde loop
         }
+        casu _ { }
     }
 
     fixum loop = scriptum("§for §(const § § §) {{\n§\n§}}", g.ind(), asyncPrefix, variabilis, keyword, genExpressia(iterabile, g), body, g.ind())

--- a/fons/rivus/codegen/zig/expressia/index.fab
+++ b/fons/rivus/codegen/zig/expressia/index.fab
@@ -158,6 +158,8 @@ functio genExpressia(Expressia expr, ZigGenerator g) -> textus {
         casu LambdaExpressia ut e {
             redde genLambda(e.parametra qua lista<LambdaParametrum>, e.corpus, g)
         }
+
+        casu _ { }
     }
 
     # Fallback

--- a/fons/rivus/codegen/zig/expressia/lambda.fab
+++ b/fons/rivus/codegen/zig/expressia/lambda.fab
@@ -30,6 +30,7 @@ functio genLambda(lista<LambdaParametrum> parametra, ignotum corpus, ZigGenerato
         casu Expressia ut e {
             redde scriptum("struct { fn f(§) anytype { return §; } }.f", params.coniunge(", "), genExpressia(e, g))
         }
+        casu _ { }
     }
 
     redde scriptum("struct { fn f(§) void {} }.f", params.coniunge(", "))

--- a/fons/rivus/codegen/zig/sententia/index.fab
+++ b/fons/rivus/codegen/zig/sententia/index.fab
@@ -98,6 +98,8 @@ functio genSententia(Sententia stmt, ZigGenerator g) -> textus {
         casu OrdoDeclaratio ut s {
             redde genOrdo(s.nomen qua textus, s.membra qua lista<OrdoMembrum>, g)
         }
+
+        casu _ { }
     }
 
     redde scriptum("§// TODO: unknown statement", g.ind())
@@ -135,6 +137,7 @@ functio genExpressiaSententia(Expressia expr, ZigGenerator g) -> textus {
         casu AssignatioExpressia {
             redde scriptum("§§;", g.ind(), e)
         }
+        casu _ { }
     }
 
     redde scriptum("§_ = §;", g.ind(), e)

--- a/fons/rivus/codegen/zig/sententia/iteratio.fab
+++ b/fons/rivus/codegen/zig/sententia/iteratio.fab
@@ -32,6 +32,7 @@ functio genIteratio(IteratioGenus species, textus variabilis, Expressia iterabil
             }
             redde scriptum("§for (@intCast(§)..@intCast(§)) |§| {\n§\n§}", g.ind(), initium, finis, variabilis, body, g.ind())
         }
+        casu _ { }
     }
 
     # Slice iteration

--- a/fons/rivus/codegen/zig/typus.fab
+++ b/fons/rivus/codegen/zig/typus.fab
@@ -89,6 +89,7 @@ functio genTypusGenericus(textus nomen, lista<TypusParametrum> parametra, bivale
                     fixum inner = genTypus(t.adnotatio, g)
                     result = scriptum("Lista(§)", inner)
                 }
+                casu _ { }
             }
             si result == "" {
                 result = "Lista(anytype)"
@@ -105,11 +106,13 @@ functio genTypusGenericus(textus nomen, lista<TypusParametrum> parametra, bivale
                     casu Typus ut t {
                         keyZig = genTypus(t.adnotatio, g)
                     }
+                    casu _ { }
                 }
                 discerne parametra[1] {
                     casu Typus ut t {
                         valZig = genTypus(t.adnotatio, g)
                     }
+                    casu _ { }
                 }
 
                 si keyZig == "[]const u8" {
@@ -130,6 +133,7 @@ functio genTypusGenericus(textus nomen, lista<TypusParametrum> parametra, bivale
                 casu Typus ut t {
                     inner = genTypus(t.adnotatio, g)
                 }
+                casu _ { }
             }
 
             si inner == "[]const u8" {
@@ -147,6 +151,7 @@ functio genTypusGenericus(textus nomen, lista<TypusParametrum> parametra, bivale
                 casu Typus ut t {
                     inner = genTypus(t.adnotatio, g)
                 }
+                casu _ { }
             }
             result = scriptum("!§", inner)
         }

--- a/fons/rivus/parser/expressia/binaria.fab
+++ b/fons/rivus/parser/expressia/binaria.fab
@@ -43,6 +43,7 @@ functio estAssignabile(Expressia expr) -> bivalens {
         casu MembrumExpressia ut m {
             redde verum
         }
+        casu _ { }
     }
 
     redde falsum

--- a/fons/rivus/parser/expressia/primaria.fab
+++ b/fons/rivus/parser/expressia/primaria.fab
@@ -710,9 +710,11 @@ functio exMassaExpressia(Sententia massa, Locus locus) -> Expressia {
                     casu ExpressiaSententia ut e {
                         redde e.expressia
                     }
+                    casu _ { }
                 }
             }
         }
+        casu _ { }
     }
 
     redde finge Littera {

--- a/fons/rivus/parser/sententia/index.fab
+++ b/fons/rivus/parser/sententia/index.fab
@@ -88,6 +88,7 @@ functio parseSententiaSineNotis(Resolvitor r) -> Sententia {
                         g.abstractum = verum
                     }
                 }
+                casu _ { }
             }
         }
 

--- a/fons/rivus/parser/typus.fab
+++ b/fons/rivus/parser/typus.fab
@@ -142,6 +142,7 @@ functio parseTypusAnnotatio(Resolvitor r) -> TypusAnnotatio {
                 casu Typus ut t {
                     unioParametra.adde(t.adnotatio)
                 }
+                casu _ { }
             }
         }
         redde {

--- a/fons/rivus/semantic/expressia/alia.fab
+++ b/fons/rivus/semantic/expressia/alia.fab
@@ -64,9 +64,11 @@ functio resolveLambda(Resolvitor r, Expressia lambdaExpr) -> SemanticTypus {
                             casu ExpressiaSententia ut s {
                                 reditusTypus = r.expressia(s.expressia)
                             }
+                            casu _ { }
                         }
                     }
                 }
+                casu _ { }
             }
             si non estMassa {
                 reditusTypus = r.expressia(l.corpus qua Expressia)
@@ -78,6 +80,7 @@ functio resolveLambda(Resolvitor r, Expressia lambdaExpr) -> SemanticTypus {
             # Build function type using resolved parameter types
             redde functioTypus(paramTypi, reditusTypus, falsum, falsum)
         }
+        casu _ { }
     }
 
     redde IGNOTUM
@@ -105,6 +108,7 @@ functio resolveFingeExpr(Resolvitor r, Expressia fingeExpr) -> SemanticTypus {
             # Otherwise use the variant name as the type
             redde usitatumTypus(f.variansNomen, falsum)
         }
+        casu _ { }
     }
 
     redde IGNOTUM
@@ -136,10 +140,12 @@ functio resolveCedeExpr(Resolvitor r, Expressia cedeExpr) -> SemanticTypus {
                         redde g.parametri.primus()
                     }
                 }
+                casu _ { }
             }
 
             redde promissumTypus
         }
+        casu _ { }
     }
 
     redde IGNOTUM
@@ -164,10 +170,12 @@ functio resolveNovumExpr(Resolvitor r, Expressia novumExpr) -> SemanticTypus {
                 casu Nomen ut nom {
                     redde usitatumTypus(nom.valor, falsum)
                 }
+                casu _ { }
             }
 
             redde IGNOTUM
         }
+        casu _ { }
     }
 
     redde IGNOTUM
@@ -189,6 +197,8 @@ functio resolveCondicio(Resolvitor r, Expressia condicioExpr) -> SemanticTypus {
             # Return the consequent type (simplification)
             redde consequensTypus
         }
+
+        casu _ { }
     }
 
     redde IGNOTUM

--- a/fons/rivus/semantic/expressia/binaria.fab
+++ b/fons/rivus/semantic/expressia/binaria.fab
@@ -25,12 +25,13 @@ functio resolveBinaria(Resolvitor r, Expressia binariaExpr) -> SemanticTypus {
             si estArithmeticum(b.signum) {
                 # String concatenation with +
                 si b.signum == "+" {
-                discerne sinisterTypus {
-                    casu Primitivum ut p {
+                    discerne sinisterTypus {
+                        casu Primitivum ut p {
                             si p.nomen == "textus" {
                                 redde TEXTUS
                             }
                         }
+                        casu _ { }
                     }
                 }
 
@@ -48,8 +49,10 @@ functio resolveBinaria(Resolvitor r, Expressia binariaExpr) -> SemanticTypus {
                                     redde sinisterTypus
                                 }
                             }
+                            casu _ { }
                         }
                     }
+                    casu _ { }
                 }
 
                 # Default to numerus
@@ -72,8 +75,10 @@ functio resolveBinaria(Resolvitor r, Expressia binariaExpr) -> SemanticTypus {
                                     a.error(err.textus, b.locus)
                                 }
                             }
+                            casu _ { }
                         }
                     }
+                    casu _ { }
                 }
 
                 redde BIVALENS
@@ -89,6 +94,7 @@ functio resolveBinaria(Resolvitor r, Expressia binariaExpr) -> SemanticTypus {
                 redde BIVALENS
             }
         }
+        casu _ { }
     }
 
     redde IGNOTUM

--- a/fons/rivus/semantic/expressia/index.fab
+++ b/fons/rivus/semantic/expressia/index.fab
@@ -191,6 +191,8 @@ functio resolveExpressia(Resolvitor r, Expressia expr) -> SemanticTypus {
 
             redde IGNOTUM
         }
+
+        casu _ { }
     }
 
     redde IGNOTUM
@@ -237,10 +239,12 @@ functio resolveAssignatio(Resolvitor r, Expressia assignatioExpr) -> SemanticTyp
                     r.expressia(m.proprietas)
                     redde dexterTypus
                 }
+                casu _ { }
             }
 
             redde dexterTypus
         }
+        casu _ { }
     }
 
     redde IGNOTUM

--- a/fons/rivus/semantic/expressia/primaria.fab
+++ b/fons/rivus/semantic/expressia/primaria.fab
@@ -40,6 +40,7 @@ functio resolveNomen(Resolvitor r, Expressia nomenExpr) -> SemanticTypus {
 
             redde symbolum.semanticTypus
         }
+        casu _ { }
     }
 
     redde IGNOTUM
@@ -75,6 +76,7 @@ functio resolveLittera(Resolvitor r, Expressia litteraExpr) -> SemanticTypus {
                 }
             }
         }
+        casu _ { }
     }
 
     redde IGNOTUM
@@ -104,6 +106,7 @@ functio resolveSeries(Resolvitor r, Expressia seriesExpr) -> SemanticTypus {
 
             redde genericumTypus("lista", [primumTypus], falsum)
         }
+        casu _ { }
     }
 
     redde IGNOTUM
@@ -126,6 +129,7 @@ functio resolveObiectum(Resolvitor r, Expressia obiectumExpr) -> SemanticTypus {
             # Object literals have unknown structural type for now
             redde IGNOTUM
         }
+        casu _ { }
     }
 
     redde IGNOTUM

--- a/fons/rivus/semantic/expressia/unaria.fab
+++ b/fons/rivus/semantic/expressia/unaria.fab
@@ -40,6 +40,7 @@ functio resolveUnaria(Resolvitor r, Expressia unariaExpr) -> SemanticTypus {
                             redde argTypus
                         }
                     }
+                    casu _ { }
                 }
                 redde NUMERUS
             }
@@ -52,6 +53,7 @@ functio resolveUnaria(Resolvitor r, Expressia unariaExpr) -> SemanticTypus {
             # Default: preserve argument type
             redde argTypus
         }
+        casu _ { }
     }
 
     redde IGNOTUM

--- a/fons/rivus/semantic/expressia/vocatio.fab
+++ b/fons/rivus/semantic/expressia/vocatio.fab
@@ -58,9 +58,11 @@ functio resolveVocatio(Resolvitor r, Expressia vocatioExpr) -> SemanticTypus {
                                     }
                                 }
                             }
+                            casu _ { }
                         }
                     }
                 }
+                casu _ { }
             }
 
             # If callee is a function type, return its return type
@@ -68,11 +70,13 @@ functio resolveVocatio(Resolvitor r, Expressia vocatioExpr) -> SemanticTypus {
                 casu Functio ut f {
                     redde f.reditusTypus
                 }
+                casu _ { }
             }
 
             # Otherwise unknown
             redde IGNOTUM
         }
+        casu _ { }
     }
 
     redde IGNOTUM
@@ -92,6 +96,7 @@ functio nomenReceptor(SemanticTypus t) -> textus? {
         casu Usitatum ut u {
             redde u.nomen
         }
+        casu _ { }
     }
     redde nihil
 }
@@ -143,6 +148,7 @@ functio resolveMembrum(Resolvitor r, Expressia membrumExpr) -> SemanticTypus {
                                     redde BIVALENS
                                 }
                             }
+                            casu _ { }
                         }
 
                         # Indexed access: lista[i] -> element type
@@ -160,6 +166,7 @@ functio resolveMembrum(Resolvitor r, Expressia membrumExpr) -> SemanticTypus {
                                     redde NUMERUS
                                 }
                             }
+                            casu _ { }
                         }
                         # Indexed access: textus[i] -> textus (single char)
                         si m.computatum {
@@ -179,12 +186,15 @@ functio resolveMembrum(Resolvitor r, Expressia membrumExpr) -> SemanticTypus {
                                 redde ge.methodi[n.valor]
                             }
                         }
+                        casu _ { }
                     }
                 }
+                casu _ { }
             }
 
             redde IGNOTUM
         }
+        casu _ { }
     }
 
     redde IGNOTUM

--- a/fons/rivus/semantic/index.fab
+++ b/fons/rivus/semantic/index.fab
@@ -124,6 +124,7 @@ functio predeclare(Resolvitor r, Sententia stmt) -> vacuum {
                             }
                         }
                     }
+                    casu _ { }
                 }
             }
         }
@@ -252,5 +253,6 @@ functio predeclare(Resolvitor r, Sententia stmt) -> vacuum {
         }
 
         # Other statements don't need predeclaration
+        casu _ { }
     }
 }

--- a/fons/rivus/semantic/modulus.fab
+++ b/fons/rivus/semantic/modulus.fab
@@ -163,6 +163,7 @@ functio extraheExporta(Programma programma, textus via) -> ModulusResolutum {
                     locus: v.locus
                 } qua ModulusExportum
             }
+            casu _ { }
         }
     }
 
@@ -246,6 +247,7 @@ functio resolveModulum(
                     resolveModulum(imp.fons, via, cache, inProgressu)
                 }
             }
+            casu _ { }
         }
     }
 

--- a/fons/rivus/semantic/sententia/actio.fab
+++ b/fons/rivus/semantic/sententia/actio.fab
@@ -34,6 +34,7 @@ functio analyzeRedde(Resolvitor r, Sententia reddeStmt) -> vacuum {
                 }
             }
         }
+        casu _ { }
     }
 }
 
@@ -49,6 +50,7 @@ functio analyzeIace(Resolvitor r, Sententia iaceStmt) -> vacuum {
             # Resolve thrown expression
             r.expressia(i.argumentum)
         }
+        casu _ { }
     }
 }
 
@@ -66,6 +68,7 @@ functio analyzeScribe(Resolvitor r, Sententia scribeStmt) -> vacuum {
                 r.expressia(arg)
             }
         }
+        casu _ { }
     }
 }
 
@@ -86,5 +89,6 @@ functio analyzeAdfirma(Resolvitor r, Sententia adfirmaStmt) -> vacuum {
                 r.expressia(adf.nuntius)
             }
         }
+        casu _ { }
     }
 }

--- a/fons/rivus/semantic/sententia/declara.fab
+++ b/fons/rivus/semantic/sententia/declara.fab
@@ -113,6 +113,7 @@ functio analyzeVariaDeclaratio(Resolvitor r, Sententia variaStmt) -> vacuum {
                 locus: v.locus
             } qua Symbolum)
         }
+        casu _ { }
     }
 }
 
@@ -197,6 +198,7 @@ functio analyzeFunctioDeclaratio(Resolvitor r, Sententia functioStmt) -> vacuum 
                 a.currentFunctioGenerator = prevGenerator
             }
         }
+        casu _ { }
     }
 }
 
@@ -254,6 +256,7 @@ functio analyzeGenusDeclaratio(Resolvitor r, Sententia genusStmt) -> vacuum {
                         # All methods are treated as instance methods for now.
                         methodi[m.nomen] = fnTypus
                     }
+                    casu _ { }
                 }
             }
 
@@ -269,6 +272,7 @@ functio analyzeGenusDeclaratio(Resolvitor r, Sententia genusStmt) -> vacuum {
                 locus: g.locus
             }
         }
+        casu _ { }
     }
 }
 
@@ -316,6 +320,7 @@ functio analyzePactumDeclaratio(Resolvitor r, Sententia pactumStmt) -> vacuum {
                 locus: p.locus
             }
         }
+        casu _ { }
     }
 }
 
@@ -344,6 +349,7 @@ functio analyzeOrdoDeclaratio(Resolvitor r, Sententia ordoStmt) -> vacuum {
                 locus: o.locus
             }
         }
+        casu _ { }
     }
 }
 
@@ -396,6 +402,7 @@ functio analyzeDiscretioDeclaratio(Resolvitor r, Sententia discretioStmt) -> vac
                 }
             }
         }
+        casu _ { }
     }
 }
 
@@ -418,5 +425,6 @@ functio analyzeTypusAlias(Resolvitor r, Sententia typusStmt) -> vacuum {
                 locus: t.locus
             }
         }
+        casu _ { }
     }
 }

--- a/fons/rivus/semantic/sententia/error.fab
+++ b/fons/rivus/semantic/sententia/error.fab
@@ -49,6 +49,7 @@ functio analyzeTempta(Resolvitor r, Sententia temptaStmt) -> vacuum {
                 r.sententia(t.demum qua Sententia)
             }
         }
+        casu _ { }
     }
 }
 
@@ -90,6 +91,7 @@ functio analyzeFac(Resolvitor r, Sententia facStmt) -> vacuum {
                 a.exiScopum()
             }
         }
+        casu _ { }
     }
 }
 
@@ -127,5 +129,6 @@ functio analyzeCura(Resolvitor r, Sententia curaStmt) -> vacuum {
 
             a.exiScopum()
         }
+        casu _ { }
     }
 }

--- a/fons/rivus/semantic/sententia/imperium.fab
+++ b/fons/rivus/semantic/sententia/imperium.fab
@@ -27,6 +27,7 @@ functio analyzeSi(Resolvitor r, Sententia siStmt) -> vacuum {
                 r.sententia(s.alternans qua Sententia)
             }
         }
+        casu _ { }
     }
 }
 
@@ -45,6 +46,7 @@ functio analyzeDum(Resolvitor r, Sententia dumStmt) -> vacuum {
             # Analyze body
             r.sententia(d.corpus)
         }
+        casu _ { }
     }
 }
 
@@ -69,6 +71,7 @@ functio analyzeIteratio(Resolvitor r, Sententia iteratioStmt) -> vacuum {
                         elemTypus = g.parametri.primus()
                     }
                 }
+                casu _ { }
             }
 
             # Define loop variable
@@ -86,6 +89,7 @@ functio analyzeIteratio(Resolvitor r, Sententia iteratioStmt) -> vacuum {
             # Exit scope
             a.exiScopum()
         }
+        casu _ { }
     }
 }
 
@@ -108,6 +112,7 @@ functio analyzeIn(Resolvitor r, Sententia inStmt) -> vacuum {
             # Exit scope
             a.exiScopum()
         }
+        casu _ { }
     }
 }
 
@@ -137,6 +142,7 @@ functio analyzeElige(Resolvitor r, Sententia eligeStmt) -> vacuum {
                 r.sententia(e.praedefinitum qua Sententia)
             }
         }
+        casu _ { }
     }
 }
 
@@ -184,6 +190,7 @@ functio analyzeDiscerne(Resolvitor r, Sententia discerneStmt) -> vacuum {
                 a.exiScopum()
             }
         }
+        casu _ { }
     }
 }
 
@@ -201,5 +208,6 @@ functio analyzeCustodi(Resolvitor r, Sententia custodiStmt) -> vacuum {
                 r.sententia(clausula.consequens)
             }
         }
+        casu _ { }
     }
 }

--- a/fons/rivus/semantic/sententia/index.fab
+++ b/fons/rivus/semantic/sententia/index.fab
@@ -143,5 +143,7 @@ functio analyzeSententia(Resolvitor r, Sententia stmt) -> vacuum {
         casu ImportaSententia {
             # Imports are processed in predeclaration phase
         }
+
+        casu _ { }
     }
 }


### PR DESCRIPTION
## Summary
- Added `casu _ { }` wildcard patterns to 29 files with non-exhaustive `discerne` (pattern match) statements
- Resolves build failures after commit e55face restored exhaustiveness checking
- Build now compiles 106/107 files (up from 78/107)

## Changes
Files modified across parser, semantic analysis, and code generation:
- **Parser (4 files)**: typus.fab, sententia/index.fab, expressia/binaria.fab, expressia/primaria.fab
- **Semantic (11 files)**: index.fab, modulus.fab, sententia/*.fab, expressia/*.fab
- **Codegen-TS (7 files)**: sententia/*.fab, expressia/*.fab
- **Codegen-Zig (5 files)**: sententia/*.fab, expressia/*.fab, typus.fab

## Notes
The remaining build error in `semantic/nucleus.fab:175` is a pre-existing type resolution issue (stdlib `tabula` return type mismatch) unrelated to this exhaustiveness fix.

## Test plan
- [x] Build rivus compiler to verify fix compiles successfully
- [x] Verify all 29 modified files now have exhaustive discerne patterns

Fixes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)