### PR TITLE
Fix {} qua copia<T> to generate new Set<T>() instead of type assertion

### DIFF
--- a/fons/faber/codegen/ts/expressions/qua.ts
+++ b/fons/faber/codegen/ts/expressions/qua.ts
@@ -5,6 +5,7 @@
  *   x qua textus -> (x as string)
  *   response.body qua objectum -> (response.body as object)
  *   { field: value } qua Genus -> new Genus({ field: value })
+ *   {} qua copia<T> -> new Set<T>()
  *
  * WHY: TypeScript uses 'as' for type assertions. Parentheses ensure
  *      correct precedence when the cast appears in larger expressions.
@@ -12,10 +13,21 @@
  * EDGE: Object literals cast to genus types need `new` instantiation,
  *       not type assertion, because genus compiles to a class with methods.
  *       Plain `as` would create an object without the class prototype.
+ *
+ * EDGE: Empty object literals cast to copia (Set) need `new Set()` construction,
+ *       not type assertion. `{} as Set<T>` creates a plain object without Set prototype.
  */
 
-import type { QuaExpression } from '../../../parser/ast';
+import type { QuaExpression, TypeAnnotation } from '../../../parser/ast';
 import type { TsGenerator } from '../generator';
+
+// WHY: TypeParameter can be TypeAnnotation | Literal. For type generation we need TypeAnnotation.
+function getTypeAnnotation(param: TypeAnnotation | { type: string }): TypeAnnotation | null {
+    if ('name' in param && param.type === 'TypeAnnotation') {
+        return param as TypeAnnotation;
+    }
+    return null;
+}
 
 export function genQuaExpression(node: QuaExpression, g: TsGenerator): string {
     const targetType = g.genType(node.targetType);
@@ -26,6 +38,15 @@ export function genQuaExpression(node: QuaExpression, g: TsGenerator): string {
     if (node.expression.type === 'ObjectExpression' && g.isGenus(targetTypeName)) {
         const props = g.genExpression(node.expression);
         return `new ${targetType}(${props})`;
+    }
+
+    // WHY: Empty object literal + copia target = Set construction, not type assertion.
+    // `{} as Set<T>` creates a plain object without Set methods like .has(), .add(), etc.
+    if (node.expression.type === 'ObjectExpression' && targetTypeName === 'copia') {
+        const typeParams = node.targetType.typeParameters;
+        const elemTypeAnno = typeParams?.[0] ? getTypeAnnotation(typeParams[0]) : null;
+        const elemType = elemTypeAnno ? g.genType(elemTypeAnno) : 'unknown';
+        return `new Set<${elemType}>()`;
     }
 
     const expr = g.genExpression(node.expression);

--- a/fons/proba/codegen/expressions/qua.yaml
+++ b/fons/proba/codegen/expressions/qua.yaml
@@ -114,3 +114,24 @@
           - 'let maybe = value as Option<i64>;'
       fab:
           - 'fixum maybe = value qua numerus?'
+
+# Empty object literal cast to copia (Set) - constructs actual Set, not type assertion
+- name: empty object to copia
+  source: fixum s = {} qua copia<textus>
+  expect:
+      ts: 'const s = new Set<string>();'
+      py: 's = {}'
+      rs:
+          - 'let s = {} as HashSet<String>;'
+      fab:
+          - 'fixum s = {} qua copia<textus>'
+
+- name: empty object to copia with numerus
+  source: fixum nums = {} qua copia<numerus>
+  expect:
+      ts: 'const nums = new Set<number>();'
+      py: 'nums = {}'
+      rs:
+          - 'let nums = {} as HashSet<i64>;'
+      fab:
+          - 'fixum nums = {} qua copia<numerus>'


### PR DESCRIPTION
## Summary

- Fixed TypeScript codegen for `{} qua copia<T>` to generate `new Set<T>()` instead of `({} as Set<T>)`
- Added helper function `getTypeAnnotation` to extract type parameters safely
- Added tests for empty object to copia casting with different type parameters

## Root Cause

When casting an empty object literal to `copia<T>` (Set), the codegen was producing `({} as Set<T>)`. This creates a plain JavaScript object and tells TypeScript to treat it as a Set, but the object lacks the Set prototype. Calling Set methods like `.has()` or `.add()` on this object throws runtime errors.

## Changes

**`fons/faber/codegen/ts/expressions/qua.ts`:**
- Added special handling for `copia` type similar to existing `genus` handling
- When target type is `copia` and expression is an empty object literal, generates `new Set<T>()` which properly constructs a Set

**`fons/proba/codegen/expressions/qua.yaml`:**
- Added two test cases verifying the fix works with `textus` and `numerus` type parameters

## Test plan

- [x] Ran `bun test fons/proba/faber.test.ts -t "@ts" -t "qua"` - all 83 tests pass
- [x] Ran full test suite `bun test fons/proba/faber.test.ts` - all 3372 tests pass
- [x] Verified compiled output of `fons/rivus/semantic/nucleus.fab` now shows `new Set<string>()` for `modulusInProgressu`

Fixes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)