### PR TITLE
Add innatum keyword support to rivus parser

### DIFF
--- a/fons/rivus/ast/expressia.fab
+++ b/fons/rivus/ast/expressia.fab
@@ -190,6 +190,15 @@ discretio Expressia {
         TypusAnnotatio scopus    # target type
     }
 
+    # Native type construction expression
+    # Example: {} innatum tabula<textus, numerus>
+    # Example: [] innatum lista<textus>
+    InnatumExpressia {
+        Locus locus
+        Expressia expressia
+        TypusAnnotatio scopus    # target type
+    }
+
     # Type check expression
     # Example: value est numerus
     EstExpressia {

--- a/fons/rivus/ast/lexema.fab
+++ b/fons/rivus/ast/lexema.fab
@@ -263,6 +263,7 @@ ordo VerbumId {
     Per
     Qua
     Ut
+    Innatum
 
     # -------------------------------------------------------------------------
     # Domain Specific (DSL)

--- a/fons/rivus/codegen/ts/expressia/index.fab
+++ b/fons/rivus/codegen/ts/expressia/index.fab
@@ -5,7 +5,7 @@
 ex "../../../ast/expressia" importa Expressia, LitteraGenus, ObiectumProprietas, LambdaParametrum, MorphologiaInvocatio
 ex "../../../ast/expressia" importa AbFiltrum, CatenaGradus
 ex "../../../ast/sententia" importa Sententia, VariaGenus
-ex "../../../ast/typus" importa TypusAnnotatio
+ex "../../../ast/typus" importa TypusAnnotatio, TypusParametrum
 ex "../nucleus" importa TsGenerator
 ex "../typus" importa genTypus
 ex "../../../parser/morphologia" importa parseMethodum
@@ -172,6 +172,104 @@ functio genExpressia(Expressia expr, TsGenerator g) -> textus {
 
         casu QuaExpressia ut e {
             redde scriptum("(§ as §)", genExpressia(e.expressia, g), genTypus(e.scopus qua TypusAnnotatio, g))
+        }
+
+        casu InnatumExpressia ut e {
+            # Native type construction
+            # {} innatum tabula<K,V> -> new Map<K,V>()
+            # [] innatum lista<T> -> ([] as T[])
+            fixum typusNomen = (e.scopus qua TypusAnnotatio).nomen qua textus
+
+            si typusNomen == "tabula" {
+                fixum params = (e.scopus qua TypusAnnotatio).typusParametra
+                varia keyType = "unknown"
+                varia valueType = "unknown"
+                si nonnihil params {
+                    fixum paramLista = params qua lista<TypusParametrum>
+                    si paramLista.longitudo() >= 1 {
+                        discerne paramLista[0] {
+                            casu Typus ut t {
+                                keyType = genTypus(t.adnotatio, g)
+                            }
+                            casu _ { }
+                        }
+                    }
+                    si paramLista.longitudo() >= 2 {
+                        discerne paramLista[1] {
+                            casu Typus ut t {
+                                valueType = genTypus(t.adnotatio, g)
+                            }
+                            casu _ { }
+                        }
+                    }
+                }
+
+                # Check for non-empty object literal
+                discerne e.expressia {
+                    casu ObiectumExpressia ut obj {
+                        si (obj.proprietates qua lista<ObiectumProprietas>).longitudo() > 0 {
+                            varia entries = [] innatum lista<textus>
+                            ex (obj.proprietates qua lista<ObiectumProprietas>) pro prop {
+                                fixum key = genExpressia(prop.clavis, g)
+                                fixum val = genExpressia(prop.valor, g)
+                                entries.adde(scriptum("[§, §]", key, val))
+                            }
+                            redde scriptum("new Map<§, §>([§])", keyType, valueType, entries.coniunge(", "))
+                        }
+                    }
+                    casu _ { }
+                }
+
+                redde scriptum("new Map<§, §>()", keyType, valueType)
+            }
+
+            si typusNomen == "lista" {
+                fixum params = (e.scopus qua TypusAnnotatio).typusParametra
+                si nonnihil params {
+                    fixum paramLista = params qua lista<TypusParametrum>
+                    si paramLista.longitudo() >= 1 {
+                        varia elemType = "unknown"
+                        discerne paramLista[0] {
+                            casu Typus ut t {
+                                elemType = genTypus(t.adnotatio, g)
+                            }
+                            casu _ { }
+                        }
+                        # Check for non-empty array
+                        discerne e.expressia {
+                            casu SeriesExpressia ut arr {
+                                si (arr.elementa qua lista<Expressia>).longitudo() > 0 {
+                                    redde genExpressia(e.expressia, g)
+                                }
+                            }
+                            casu _ { }
+                        }
+                        redde scriptum("([] as §[])", elemType)
+                    }
+                }
+                redde "[]"
+            }
+
+            si typusNomen == "copia" {
+                fixum params = (e.scopus qua TypusAnnotatio).typusParametra
+                si nonnihil params {
+                    fixum paramLista = params qua lista<TypusParametrum>
+                    si paramLista.longitudo() >= 1 {
+                        varia elemType = "unknown"
+                        discerne paramLista[0] {
+                            casu Typus ut t {
+                                elemType = genTypus(t.adnotatio, g)
+                            }
+                            casu _ { }
+                        }
+                        redde scriptum("new Set<§>()", elemType)
+                    }
+                }
+                redde "new Set()"
+            }
+
+            # Fallback: just generate the expression
+            redde genExpressia(e.expressia, g)
         }
 
         casu EstExpressia ut e {

--- a/fons/rivus/lexicon/verba.fab
+++ b/fons/rivus/lexicon/verba.fab
@@ -150,6 +150,7 @@ functio verbumFaberId(textus v) -> VerbumId? {
         casu "per" reddit VerbumId.Per
         casu "qua" reddit VerbumId.Qua
         casu "ut" reddit VerbumId.Ut
+        casu "innatum" reddit VerbumId.Innatum
 
         # ---- Domain Specific (DSL) ----
         casu "ab" reddit VerbumId.Ab

--- a/fons/rivus/parser/expressia/unaria.fab
+++ b/fons/rivus/parser/expressia/unaria.fab
@@ -1,14 +1,15 @@
 # Unary and Postfix Expression Parsers
 #
 # Prefix operators: non, -, ~, cede, novum, etc.
-# Postfix operators: qua (type cast), call, member access
+# Postfix operators: qua (type cast), innatum (native construction), call, member access
 #
 # GRAMMAR:
 #   unary := ('non' | '-' | '~' | 'cede' | 'novum') unary | postfix
-#   postfix := primary (callSuffix | memberSuffix | quaSuffix)*
+#   postfix := primary (callSuffix | memberSuffix | quaSuffix | innatumSuffix)*
 #   callSuffix := '(' arguments ')'
 #   memberSuffix := '.' IDENTIFIER | '[' expr ']'
 #   quaSuffix := 'qua' typeAnnotation
+#   innatumSuffix := 'innatum' typeAnnotation
 #
 # LATIN VOCABULARY:
 # - unaria = unary
@@ -16,6 +17,7 @@
 # - cede = yield/await
 # - novum = new
 # - qua = as (type cast)
+# - innatum = native (type construction)
 
 ex "../resolvitor" importa Resolvitor
 ex "../../ast/positio" importa Locus
@@ -351,6 +353,19 @@ functio parsePostfix(Resolvitor r) -> Expressia {
             fixum scopus = r.adnotatio()
 
             expressia = finge QuaExpressia {
+                locus: locus,
+                expressia: expressia,
+                scopus: scopus
+            } qua Expressia
+            perge
+        }
+
+        # Native type construction: expr innatum Type
+        # Example: {} innatum tabula<textus, numerus>
+        si p.congruetVerbum("innatum") {
+            fixum scopus = r.adnotatio()
+
+            expressia = finge InnatumExpressia {
                 locus: locus,
                 expressia: expressia,
                 scopus: scopus


### PR DESCRIPTION
## Summary
- Fixes the rivus parser failing to handle the `innatum` keyword for native type construction
- Resolves "Expected expression: got ','" errors when parsing generic types with multiple type parameters (e.g., `tabula<textus, ModulusExportum>`)
- The `innatum` keyword was not registered in the rivus lexer, causing it to be treated as an identifier instead of a keyword

## Changes
- Add `Innatum` to `VerbumId` enum in `lexema.fab`
- Add `"innatum"` keyword mapping in `verba.fab`
- Add `InnatumExpressia` variant to `Expressia` discretio
- Add `innatum` postfix expression handling in `unaria.fab` parser
- Add TypeScript codegen for `InnatumExpressia` (generates `new Map<>()`, arrays, `new Set<>()`)

## Test plan
- [x] Verify `{} innatum tabula<textus, numerus>` compiles correctly to `new Map<string, number>()`
- [x] Verify `[] innatum lista<textus>` compiles correctly to `([] as string[])`
- [x] Verify the original failing pattern from the issue works

Fixes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)