### PR TITLE
Fix rivus codegen: apply norma-registry method translations

### DIFF
--- a/fons/rivus/codegen/ts/expressia/index.fab
+++ b/fons/rivus/codegen/ts/expressia/index.fab
@@ -10,12 +10,12 @@ ex "../nucleus" importa TsGenerator
 ex "../typus" importa genTypus
 ex "../../../parser/morphologia" importa parseMethodum
 ex "../../radices" importa generaListaMethodum
+ex "../../norma-registry.gen" importa getNormaTranslation, VerteTranslation
 ex "./littera" importa genLittera, genLitteraExemplar
 ex "./scriptum" importa genScriptum
 ex "./ambitus" importa genAmbitusExpressia
 ex "./est" importa genEstExpressia, genEstExpressiaNegata
 ex "./obiectum" importa genObiectum
-
 # =============================================================================
 # EXPRESSION DISPATCH
 # =============================================================================
@@ -206,29 +206,49 @@ functio genExpressia(Expressia expr, TsGenerator g) -> textus {
                 args.adde(genExpressia(arg, g))
             }
 
-            # WHY: Morphology dispatch is receiver-bound and semantic-gated.
-            si nonnihil e.morphologia {
-                discerne e.vocatum {
-                    casu MembrumExpressia ut m {
-                        si non (m.computatum qua bivalens) {
-                            discerne m.proprietas {
-                                casu Nomen ut prop {
-                                    fixum methodNomen = prop.valor qua textus
+            # WHY: Check for stdlib method translation via norma-registry.
+            # This handles lista, tabula, copia, textus, etc. method calls.
+            discerne e.vocatum {
+                casu MembrumExpressia ut m {
+                    si non (m.computatum qua bivalens) {
+                        discerne m.proprietas {
+                            casu Nomen ut prop {
+                                fixum methodNomen = prop.valor qua textus
+                                fixum obj = genExpressia(m.obiectum, g)
+
+                                # WHY: Try norma translation if we have receiver type info.
+                                si nonnihil e.morphologia {
+                                    fixum recipiens = (e.morphologia qua MorphologiaInvocatio).recipiens
+                                    fixum translation = getNormaTranslation("ts", recipiens, methodNomen)
+
+                                    si nonnihil translation {
+                                        # Simple method rename: use translated method name
+                                        si nonnihil translation.method {
+                                            fixum optMark = (e.optivum qua bivalens) sic "?." secus ""
+                                            redde scriptum("§§.§(§)", obj, optMark, translation.method, args.coniunge(", "))
+                                        }
+
+                                        # Template-based translation
+                                        si nonnihil translation.template et nonnihil translation.params {
+                                            redde applyNormaTemplate(translation.template qua textus, translation.params qua lista<textus>, obj, args)
+                                        }
+                                    }
+
+                                    # Fallback: generaListaMethodum for lista morphology patterns
                                     fixum parsed = parseMethodum(methodNomen)
-                                    si nonnihil parsed et (e.morphologia qua MorphologiaInvocatio).recipiens == "lista" {
-                                        fixum obj = genExpressia(m.obiectum, g)
+                                    si nonnihil parsed et recipiens == "lista" {
                                         fixum result = generaListaMethodum((e.morphologia qua MorphologiaInvocatio).radix, obj, args, parsed.flagga)
                                         si nonnihil result {
                                             redde result
                                         }
                                     }
                                 }
-                                casu _ { }
                             }
+                            casu _ { }
                         }
                     }
-                    casu _ { }
                 }
+                casu _ { }
             }
 
             # Default: pass through as-is
@@ -686,6 +706,80 @@ functio legeNumerusTextus(textus crudus) -> numerus {
         result = result * 10 + digit
         i += 1
     }
+    redde result
+}
+
+# =============================================================================
+# NORMA TRANSLATION HELPERS
+# =============================================================================
+
+# Apply a norma template translation with parameter substitution.
+# WHY: Norma templates use § placeholders that map to params.
+# - 'ego' maps to the receiver object
+# - Other params consume args in order
+# - §0, §1 etc. are explicit indices into the values array
+# - Plain § uses implicit positional indexing
+functio applyNormaTemplate(textus template, lista<textus> params, textus obj, lista<textus> args) -> textus {
+    # Build values array: ego -> obj, other params -> args
+    varia values = [] innatum lista<textus>
+    varia argIdx = 0
+    ex params pro param {
+        si param == "ego" {
+            values.adde(obj)
+        } secus {
+            si argIdx < args.longitudo() {
+                values.adde(args[argIdx])
+                argIdx += 1
+            } secus {
+                values.adde("")
+            }
+        }
+    }
+
+    # Replace § placeholders
+    varia result = ""
+    varia i = 0
+    varia implicitIdx = 0
+
+    dum i < template.longitudo() {
+        fixum c = template[i]
+        si c == "§" {
+            # Check for explicit index (§0, §1, etc.)
+            si i + 1 < template.longitudo() {
+                fixum next = template[i + 1]
+                si next >= "0" et next <= "9" {
+                    # Parse the index
+                    varia idxStr = ""
+                    varia j = i + 1
+                    dum j < template.longitudo() {
+                        fixum digit = template[j]
+                        si digit >= "0" et digit <= "9" {
+                            idxStr = idxStr + digit
+                            j += 1
+                        } secus {
+                            rumpe
+                        }
+                    }
+                    fixum idx = legeNumerusTextus(idxStr)
+                    si idx < values.longitudo() {
+                        result = result + values[idx]
+                    }
+                    i = j
+                    perge
+                }
+            }
+            # Implicit positional: plain §
+            si implicitIdx < values.longitudo() {
+                result = result + values[implicitIdx]
+            }
+            implicitIdx += 1
+            i += 1
+        } secus {
+            result = result + c
+            i += 1
+        }
+    }
+
     redde result
 }
 

--- a/fons/rivus/semantic/expressia/vocatio.fab
+++ b/fons/rivus/semantic/expressia/vocatio.fab
@@ -30,13 +30,20 @@ functio resolveVocatio(Resolvitor r, Expressia vocatioExpr) -> SemanticTypus {
                     si non (m.computatum qua bivalens) {
                         discerne m.proprietas {
                             casu Nomen ut n {
-                                fixum parsed = parseMethodum(n.valor)
-                                si nonnihil parsed {
-                                    fixum obiectumTypus = r.expressia(m.obiectum)
-                                    fixum recipiens = nomenReceptor(obiectumTypus)
-                                    si nonnihil recipiens {
-                                        fixum receiver = recipiens qua textus
-                                        si r.analyzator().habetMorphologiam(receiver) {
+                                fixum obiectumTypus = r.expressia(m.obiectum)
+                                fixum recipiens = nomenReceptor(obiectumTypus)
+
+                                # WHY: Set morphologia for method calls on known stdlib collection types.
+                                # This enables norma-registry translation in codegen even for methods
+                                # that don't have Latin morphology (like habet, accipe, pone).
+                                si nonnihil recipiens {
+                                    fixum receiver = recipiens qua textus
+
+                                    # Check if this is a known stdlib collection for norma translation
+                                    si receiver inter ["lista", "tabula", "copia", "textus", "numerus", "fractus"] {
+                                        fixum parsed = parseMethodum(n.valor)
+
+                                        si nonnihil parsed et r.analyzator().habetMorphologiam(receiver) {
                                             fixum formae = r.analyzator().formaeMorphologiae(receiver, parsed.radix)
 
                                             # EDGE: Avoid lexical hijacking. Only treat a call as morphologia if
@@ -54,6 +61,18 @@ functio resolveVocatio(Resolvitor r, Expressia vocatioExpr) -> SemanticTypus {
                                                     } qua MorphologiaInvocatio
                                                 }
                                             }
+                                        }
+
+                                        # Fallback: set morphologia with method name as-is for norma translation
+                                        # WHY: Methods like 'habet', 'accipe' don't parse as morphology but
+                                        # still need norma translation. The codegen uses recipiens to look up
+                                        # the translation.
+                                        si nihil v.morphologia {
+                                            v.morphologia = {
+                                                recipiens: receiver,
+                                                radix: n.valor,
+                                                forma: "directum"
+                                            } qua MorphologiaInvocatio
                                         }
                                     }
                                 }


### PR DESCRIPTION
## Summary

Fixes the issue where rivus-compiled code used Latin method names directly instead of applying norma-registry translations, causing runtime errors like `TypeError: s.habet is not a function`.

- Import and call `getNormaTranslation` from `norma-registry.gen.fab` in the rivus TypeScript codegen
- Add `applyNormaTemplate` helper for template-based translations (e.g., `addita` → `[...ego, elem]`)
- Modify semantic phase to set `morphologia` for ALL method calls on stdlib collections, enabling norma translation even for methods that don't parse as Latin verb morphology (like `habet`, `accipe`, `pone`)

### Before
```bash
echo 'fixum s = {} qua copia<textus>
scribe s.habet("a")' | bun run rivus compile /dev/stdin
# Output: s.habet("a") → TypeError at runtime
```

### After
```bash
echo 'fixum s = {} qua copia<textus>
scribe s.habet("a")' | bun run rivus compile /dev/stdin
# Output: s.has("a") → Works correctly
```

## Test plan

- [x] Verify `copia.habet()` translates to `.has()` in TypeScript output
- [x] Verify `tabula.pone()` translates to `.set()` and `tabula.accipe()` to `.get()`
- [x] Verify `lista.adde()` translates to `.push()`
- [x] Verify template-based translations like `lista.addita()` → `[...ego, elem]` work
- [x] Rebuild rivus with `bun run build:rivus` successfully
- [x] Run norma-registry tests: `bun test fons/faber/codegen/norma-registry.test.ts`

Fixes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)