### PR TITLE
Allow keywords as identifiers in rivus parser where appropriate

### DIFF
--- a/fons/rivus/parser/expressia/primaria.fab
+++ b/fons/rivus/parser/expressia/primaria.fab
@@ -476,7 +476,7 @@ functio parseObiectumExpressia(Resolvitor r) -> Expressia {
                 }
                 # Identifier key: name
                 secus {
-                    fixum nomenSym = p.expecta(SymbolumGenus.Nomen, ParserErrorCodice.ExpectaturNomen)
+                    fixum nomenSym = p.expectaNomenAutVerbum(ParserErrorCodice.ExpectaturNomen)
                     clavis = finge Nomen {
                         locus: nomenSym.locus,
                         valor: nomenSym.valor
@@ -552,7 +552,7 @@ functio parseLambdaExpressia(Resolvitor r) -> Expressia {
         # Parse parameters until we hit : or ->
         fac {
             fixum paramLocus = p.locusActualis()
-            fixum nomenSym = p.expecta(SymbolumGenus.Nomen, ParserErrorCodice.ExpectaturNomen)
+            fixum nomenSym = p.expectaNomenAutVerbum(ParserErrorCodice.ExpectaturNomen)
 
             parametra.adde({
                 locus: paramLocus,
@@ -609,7 +609,7 @@ functio parseFingeExpressia(Resolvitor r) -> Expressia {
             fac {
                 fixum campusLocus = p.locusActualis()
 
-                fixum nomenSym = p.expecta(SymbolumGenus.Nomen, ParserErrorCodice.ExpectaturNomen)
+                fixum nomenSym = p.expectaNomenAutVerbum(ParserErrorCodice.ExpectaturNomen)
                 # WHY: Keep Nomen as Expressia to avoid TS literal widening.
                 fixum Expressia clavis = finge Nomen {
                     locus: nomenSym.locus,

--- a/fons/rivus/parser/nucleus.fab
+++ b/fons/rivus/parser/nucleus.fab
@@ -366,6 +366,43 @@ genus Parser {
         } qua Symbolum
     }
 
+    # Expect identifier or keyword (for positions where keywords can be used as names)
+    # WHY: In positions like object property names, pattern match bindings, and
+    #      import/export specifiers, keywords should be allowed as identifiers.
+    #      E.g., { typus: value }, casu Type ut est { ... }, ex lib importa scribe
+    # Returns matched token if found, synthetic token after advancing if not
+    @ publica
+    functio expectaNomenAutVerbum(ParserErrorCodice codice) -> Symbolum {
+        fixum s = ego.specta(0)
+
+        # Accept identifier tokens
+        si s.species === SymbolumGenus.Nomen {
+            redde ego.procede()
+        }
+
+        # Accept keyword tokens as identifiers in this context
+        si s.species === SymbolumGenus.Verbum {
+            redde ego.procede()
+        }
+
+        # Record error with context
+        ego.renuncia(codice, scriptum("got '§'", s.valor))
+
+        # Advance past unexpected token
+        si non ego.estFinis() {
+            ego.procede()
+        }
+
+        # Return synthetic identifier token
+        redde {
+            species: SymbolumGenus.Nomen,
+            valor: "",
+            locus: s.locus,
+            verbum: nihil,
+            verbumId: nihil
+        } qua Symbolum
+    }
+
     # =========================================================================
     # Error Recovery
     # synchrona = skip to next statement boundary after error

--- a/fons/rivus/parser/sententia/fluxus.fab
+++ b/fons/rivus/parser/sententia/fluxus.fab
@@ -144,7 +144,7 @@ functio parseDiscerneSententia(Resolvitor r) -> Sententia {
             p.procede()  # Consume 'casu'
 
             # Parse variant name
-            fixum variansNomenSym = p.expecta(SymbolumGenus.Nomen, ParserErrorCodice.ExpectaturNomen)
+            fixum variansNomenSym = p.expectaNomenAutVerbum(ParserErrorCodice.ExpectaturNomen)
             fixum variansNomen = variansNomenSym.valor
 
             # Parse optional bindings: ut alias OR pro x, y, z
@@ -153,12 +153,12 @@ functio parseDiscerneSententia(Resolvitor r) -> Sententia {
             varia vincula = [] innatum lista<textus>
             si p.probaVerbum("ut") {
                 p.procede()
-                fixum aliasSym = p.expecta(SymbolumGenus.Nomen, ParserErrorCodice.ExpectaturNomen)
+                fixum aliasSym = p.expectaNomenAutVerbum(ParserErrorCodice.ExpectaturNomen)
                 alias = aliasSym.valor
             } sin p.probaVerbum("pro") {
                 p.procede()
                 fac {
-                    fixum vincSym = p.expecta(SymbolumGenus.Nomen, ParserErrorCodice.ExpectaturNomen)
+                    fixum vincSym = p.expectaNomenAutVerbum(ParserErrorCodice.ExpectaturNomen)
                     vincula.adde(vincSym.valor)
                 } dum p.congruet(SymbolumGenus.Coma)
             }
@@ -258,7 +258,7 @@ functio parseCapeClausula(Resolvitor r) -> CapeClausula {
     p.procede()
 
     # Parse error binding name
-    fixum paramSym = p.expecta(SymbolumGenus.Nomen, ParserErrorCodice.ExpectaturNomen)
+    fixum paramSym = p.expectaNomenAutVerbum(ParserErrorCodice.ExpectaturNomen)
     fixum param = paramSym.valor
 
     # Parse body


### PR DESCRIPTION
## Summary

- Add `expectaNomenAutVerbum()` helper to Parser in `nucleus.fab` that accepts either identifier (Nomen) or keyword (Verbum) tokens
- Apply fix to object literal property names, pattern match bindings, catch clause params, lambda params, and finge expression fields
- Matches behavior of faber reference compiler's `parseIdentifierOrKeyword()` function

## Details

The rivus parser was rejecting keywords like `typus`, `est`, and `exporta` when used as identifiers in specific syntactic positions where they should be allowed. This was blocking rivus from compiling files that use these common words as identifiers.

**Before:** Parser errors like:
```
113:21 - Expected identifier: got 'typus'
121:42 - Expected identifier: got 'est'
```

**After:** Keywords are accepted as identifiers in appropriate contexts.

## Test plan

- [x] Build rivus successfully with `bun run build:rivus`
- [x] Verify `typus` errors no longer appear when compiling `fons/rivus/semantic/modulus.fab`
- [x] Verify `est` errors no longer appear when compiling `fons/rivus/codegen/ts/expressia/index.fab`
- [x] Run test suite - no new regressions introduced

Fixes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)