### PR TITLE
Fix rivus parser: verum/falsum/nihil prefix operators respect line boundaries

### DIFF
--- a/fons/rivus/parser/expressia/unaria.fab
+++ b/fons/rivus/parser/expressia/unaria.fab
@@ -120,7 +120,12 @@ functio parseUnaria(Resolvitor r) -> Expressia {
         redde estInitiumExpressiae(s)
     }
 
-    si p.proba(SymbolumGenus.Nihil) et estInitiumPostNihil(prox) et prox.species !== SymbolumGenus.UncusSin {
+    # WHY: Only treat these as prefix unary operators if operand is on the same line.
+    #      This prevents `verum\ni += 1` from being parsed as `(verum i) += 1`.
+    fixum actualis = p.specta(0)
+    fixum eademLinea = actualis.locus.linea == prox.locus.linea
+
+    si p.proba(SymbolumGenus.Nihil) et eademLinea et estInitiumPostNihil(prox) et prox.species !== SymbolumGenus.UncusSin {
         # WHY: Avoid treating block starts as unary operands (si x == nihil { ... }).
         p.procede()
         fixum argumentum = parseUnaria(r)
@@ -132,7 +137,7 @@ functio parseUnaria(Resolvitor r) -> Expressia {
     }
 
     # Boolean true check: verum x -> x === true
-    si p.proba(SymbolumGenus.Verum) et estInitiumPostNihil(prox) et prox.species !== SymbolumGenus.UncusSin {
+    si p.proba(SymbolumGenus.Verum) et eademLinea et estInitiumPostNihil(prox) et prox.species !== SymbolumGenus.UncusSin {
         p.procede()
         fixum argumentum = parseUnaria(r)
         redde finge UnariaExpressia {
@@ -143,7 +148,7 @@ functio parseUnaria(Resolvitor r) -> Expressia {
     }
 
     # Boolean false check: falsum x -> x === false
-    si p.proba(SymbolumGenus.Falsum) et estInitiumPostNihil(prox) et prox.species !== SymbolumGenus.UncusSin {
+    si p.proba(SymbolumGenus.Falsum) et eademLinea et estInitiumPostNihil(prox) et prox.species !== SymbolumGenus.UncusSin {
         p.procede()
         fixum argumentum = parseUnaria(r)
         redde finge UnariaExpressia {


### PR DESCRIPTION
## Summary

- Fixes the rivus parser to correctly handle compound assignment operators (`+=`, `-=`, etc.) when they follow `verum`, `falsum`, or `nihil` literals on the next line
- The root cause was the prefix unary operator parsing for truthiness checks (`verum x` -> `x === true`) incorrectly consuming identifiers across newlines
- Added a same-line check so these operators only bind to operands on the same line

## Root Cause Analysis

The rivus parser supports `verum x` as syntactic sugar for `x === true` (and similarly for `falsum x` and `nihil x`). However, the parser was consuming tokens across newlines:

```fab
varia y = verum
i += 1  # Parsed incorrectly as `verum i` followed by `+= 1`
```

This caused the "Invalid assignment target" error because `+= 1` has no left-hand side.

## The Fix

Added a same-line check in `fons/rivus/parser/expressia/unaria.fab` so the prefix unary operators only consume the next token as an operand if it's on the same line as the operator.

## Test plan

- [x] Rebuild rivus and verify compound assignment now works after `verum`/`falsum`/`nihil` on previous line
- [x] Verify `verum x` on the same line still works as expected
- [x] Run `bun test -t "compound"` - passes
- [x] Run `bun run build:rivus` - builds successfully

Fixes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)