### PR TITLE
Fix predeclaration using VACUUM placeholder for forward function calls

### DIFF
--- a/fons/rivus/semantic/index.fab
+++ b/fons/rivus/semantic/index.fab
@@ -88,11 +88,14 @@ functio predeclare(Resolvitor r, Sententia stmt) -> vacuum {
         # Function declaration - register name with function type
         casu FunctioDeclaratio ut f {
             # Build placeholder function type
+            # WHY: Use IGNOTUM (not VACUUM) when return type is declared, matching faber.
+            # This allows forward function calls to pass type checks during body analysis.
             varia paramTypi = [] innatum lista<SemanticTypus>
             ex f.parametra pro param {
                 paramTypi.adde(IGNOTUM)
             }
-            fixum fnTypus = functioTypus(paramTypi, VACUUM, f.asynca, falsum)
+            fixum reditusTypus = nonnihil f.typusReditus sic IGNOTUM secus VACUUM
+            fixum fnTypus = functioTypus(paramTypi, reditusTypus, f.asynca, falsum)
 
             a.definie({
                 nomen: f.nomen,


### PR DESCRIPTION
## Summary

- Fixes the rivus semantic analyzer's predeclaration to use IGNOTUM (UNKNOWN) instead of VACUUM as the placeholder return type when a function has a return type annotation
- This matches faber's behavior and allows forward function calls to pass type checks during body analysis
- Eliminates ~50 type mismatch errors during bootstrap compilation

## Root Cause

During predeclaration (Phase 1), function return types were set to `VACUUM`. When function A calls function B (defined later in the file), B's return type was still `VACUUM` during A's body analysis, causing errors like:

```
Return type 'vacuum' is not assignable to function return type 'Expressia'
```

## Fix

Changed `fons/rivus/semantic/index.fab` predeclaration logic from:

```fab
fixum fnTypus = functioTypus(paramTypi, VACUUM, f.asynca, falsum)
```

to:

```fab
fixum reditusTypus = nonnihil f.typusReditus sic IGNOTUM secus VACUUM
fixum fnTypus = functioTypus(paramTypi, reditusTypus, f.asynca, falsum)
```

Now functions with return type annotations use `IGNOTUM` (which is assignable to any type), while void functions still use `VACUUM`.

## Test plan

- [x] `bun run build:rivus` compiles successfully
- [x] No "vacuum" type errors in bootstrap output

Fixes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)