### PR TITLE
Fix rivus semantic: guard member property resolution with computatum check

### DIFF
--- a/fons/rivus/semantic/expressia/index.fab
+++ b/fons/rivus/semantic/expressia/index.fab
@@ -236,7 +236,11 @@ functio resolveAssignatio(Resolvitor r, Expressia assignatioExpr) -> SemanticTyp
                 casu MembrumExpressia ut m {
                     # TODO: Resolve member types once genus metadata exists.
                     r.expressia(m.obiectum)
-                    r.expressia(m.proprietas)
+                    # WHY: Only resolve property for computed (indexed) access.
+                    # For dot access (obj.field), property is a field name, not a variable.
+                    si m.computatum {
+                        r.expressia(m.proprietas)
+                    }
                     redde dexterTypus
                 }
                 casu _ { }


### PR DESCRIPTION
## Summary

- Guards property resolution in `resolveAssignatio` with a `computatum` check
- For dot access (`obj.field`), the property is a field identifier, not a variable reference
- Mirrors the existing fix in `resolveMembrum` (vocatio.fab:147-149)
- Eliminates 35+ spurious "Undefined variable" errors during bootstrap build

## Test plan

- [x] `bun run build:rivus` succeeds (previously failed with 35+ semantic errors)
- [x] `bun run test:rivus` shows no regressions (755 pass, 30 fail - same as baseline)

Fixes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)