### PR TITLE
Fix rivus predeclaration: use IGNOTUM for declared return types

### DIFF
--- a/fons/rivus/semantic/index.fab
+++ b/fons/rivus/semantic/index.fab
@@ -92,7 +92,10 @@ functio predeclare(Resolvitor r, Sententia stmt) -> vacuum {
             ex f.parametra pro param {
                 paramTypi.adde(IGNOTUM)
             }
-            fixum fnTypus = functioTypus(paramTypi, VACUUM, f.asynca, falsum)
+            # WHY: Use IGNOTUM when return type is declared, matching faber behavior.
+            # This allows forward function calls to pass type checks during body analysis.
+            fixum reditusTypus = nonnihil f.typusReditus sic IGNOTUM secus VACUUM
+            fixum fnTypus = functioTypus(paramTypi, reditusTypus, f.asynca, falsum)
 
             a.definie({
                 nomen: f.nomen,


### PR DESCRIPTION
## Summary

Fixes #51 - Clean replacement for rejected PR #53.

Uses `IGNOTUM` instead of `VACUUM` when a function has a declared return type during predeclaration. This matches faber's behavior and allows forward function calls to pass type checks during body analysis.

## Changes

Single change to `fons/rivus/semantic/index.fab`:

```fab
fixum reditusTypus = nonnihil f.typusReditus sic IGNOTUM secus VACUUM
fixum fnTypus = functioTypus(paramTypi, reditusTypus, f.asynca, falsum)
```

## Why PR #53 was rejected

PR #53 included the correct fix but also had stale changes that would have reverted PR #52's block scoping fix. This PR contains only the predeclaration fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)