### PR TITLE
Implement multi-discriminant discerne in rivus parser

### DIFF
--- a/fons/rivus/ast/sententia.fab
+++ b/fons/rivus/ast/sententia.fab
@@ -196,15 +196,25 @@ genus EligeCasus {
     Sententia consequens         # MassaSententia
 }
 
+# Single pattern in a variant case (matches one discriminant)
+# Example: Primitivum ut p, Click pro x, y, _, Quit
+@ publicum
+genus VariansExemplar {
+    Locus locus
+    textus variansNomen          # variant tag or "_" for wildcard
+    bivalens estWildcard         # true for _ patterns
+    textus? alias                # 'ut' binds entire variant
+    lista<textus> vincula        # field bindings from 'pro'
+}
+
 # Variant case for discerne (pattern matching)
-# Example: si Click pro x, y { ... }
+# Example: casu Click pro x, y { ... }
+# Example: casu Primitivum ut l, Primitivum ut r { ... }  (multi-discriminant)
 @ publicum
 genus VariansCasus {
     Locus locus
-    textus variansNomen
-    textus? alias                # 'ut' binds entire variant
-    lista<textus> vincula        # field bindings from 'pro'
-    Sententia consequens         # MassaSententia
+    lista<VariansExemplar> exemplaria  # patterns (one per discriminant)
+    Sententia consequens               # MassaSententia
 }
 
 # Guard clause
@@ -433,10 +443,11 @@ discretio Sententia {
     }
 
     # Pattern matching statement
-    # Example: discerne event { si Click pro x, y { ... } }
+    # Example: discerne event { casu Click pro x, y { ... } }
+    # Example: discerne a, b { casu X ut x, Y ut y { ... } }  (multi-discriminant)
     DiscerneSententia {
         Locus locus
-        Expressia discriminans
+        lista<Expressia> discriminantes   # one or more expressions to match against
         lista<VariansCasus> casus
     }
 

--- a/fons/rivus/codegen/ts/sententia/discerne.fab
+++ b/fons/rivus/codegen/ts/sententia/discerne.fab
@@ -3,12 +3,23 @@
 # Generates if/else chains for discriminated union matching.
 #
 # TRANSFORMS:
+#   # Single discriminant
 #   discerne x { casu A {...} }       -> if (x.tag === 'A') {...}
 #   discerne x { casu B ut b {...} }  -> if (x.tag === 'B') { const b = x; ... }
 #   discerne x { casu C pro a, b {...} } -> if (x.tag === 'C') { const { a, b } = x; ... }
 #   discerne x { casu _ {...} }       -> else {...}  (wildcard pattern)
+#
+#   # Multi-discriminant
+#   discerne left, right {
+#       casu Primitivum ut l, Primitivum ut r { redde l.nomen == r.nomen }
+#       casu _, _ { redde falsum }
+#   }
+#   -> if (left.tag === 'Primitivum' && right.tag === 'Primitivum') {
+#          const l = left; const r = right;
+#          return l.nomen === r.nomen;
+#      } else { return false; }
 
-ex "../../../ast/sententia" importa Sententia, VariansCasus
+ex "../../../ast/sententia" importa Sententia, VariansCasus, VariansExemplar
 ex "../../../ast/expressia" importa Expressia
 ex "../nucleus" importa TsGenerator
 
@@ -17,48 +28,80 @@ ex "../expressia/index" importa genExpressia
 ex "./index" importa genSententia
 
 @ publica
-functio genDiscerne(Expressia discriminans, lista<VariansCasus> casus, TsGenerator g) -> textus {
-    fixum disc = genExpressia(discriminans, g)
-    varia result = scriptum("§// discerne §\n", g.ind(), disc)
+functio genDiscerne(lista<Expressia> discriminantes, lista<VariansCasus> casus, TsGenerator g) -> textus {
+    # Generate expressions for all discriminants
+    varia discriminantStrs = [] innatum lista<textus>
+    ex discriminantes pro d {
+        discriminantStrs.adde(genExpressia(d, g))
+    }
+
+    varia result = scriptum("§// discerne\n", g.ind())
 
     varia first = verum
     ex casus pro c {
-        # WHY: Wildcard pattern (_) matches anything - generates else block
-        fixum estWildcard = c.variansNomen == "_"
+        # Build combined condition for all patterns
+        varia conditions = [] innatum lista<textus>
+        varia i = 0
+        ex c.exemplaria pro pattern {
+            # Wildcard matches anything - no condition needed
+            si non pattern.estWildcard {
+                fixum disc = discriminantStrs[i]
+                conditions.adde(scriptum("§.tag === '§'", disc, pattern.variansNomen))
+            }
+            i += 1
+        }
 
-        si estWildcard {
-            # Wildcard: generate else block (no condition)
+        # If all patterns are wildcards, this is a catch-all
+        si conditions.longitudo() == 0 {
+            # Generate as else block if not first case, otherwise unconditional
             si first {
-                # If first case is wildcard, just open a block (unconditional)
-                result = scriptum("§§{{\n", result, g.ind())
+                result = scriptum("§§{\n", result, g.ind())
             } secus {
-                result = scriptum("§§else {{\n", result, g.ind())
+                result = scriptum("§§else {\n", result, g.ind())
             }
         } secus {
-            # Normal variant: generate if/else if with tag check
+            fixum condition = conditions.coniunge(" && ")
             si first {
-                result = scriptum("§§if (§.tag === '§') {{\n", result, g.ind(), disc, c.variansNomen)
+                result = scriptum("§§if (§) {\n", result, g.ind(), condition)
                 first = falsum
             } secus {
-                result = scriptum("§§else if (§.tag === '§') {{\n", result, g.ind(), disc, c.variansNomen)
+                result = scriptum("§§else if (§) {\n", result, g.ind(), condition)
             }
         }
 
         g.intraProfundum()
 
-        # Bind alias or fields (only for non-wildcard patterns)
-        si non estWildcard {
-            si nonnihil c.alias {
-                # WHY: 'ut' binds the whole variant for access via alias.
-                result = scriptum("§§const § = §;\n", result, g.ind(), c.alias, disc)
-            } sin c.vincula.longitudo() > 0 {
-                result = scriptum("§§const {{ § }} = §;\n", result, g.ind(), c.vincula.coniunge(", "), disc)
+        # Generate bindings for each pattern
+        varia j = 0
+        ex c.exemplaria pro pattern {
+            # Skip wildcards - no bindings
+            si non pattern.estWildcard {
+                fixum disc = discriminantStrs[j]
+                result = scriptum("§§", result, genPatternBindings(pattern, disc, g))
             }
+            j += 1
         }
 
+        # Generate body statements
         result = scriptum("§§\n", result, genSententia(c.consequens, g))
         g.exiProfundum()
-        result = scriptum("§§}}\n", result, g.ind())
+        result = scriptum("§§}\n", result, g.ind())
+    }
+
+    redde result
+}
+
+# Generate bindings for a single pattern
+functio genPatternBindings(VariansExemplar pattern, textus discriminant, TsGenerator g) -> textus {
+    varia result = ""
+
+    # Alias binding: casu Click ut c
+    si nonnihil pattern.alias {
+        result = scriptum("§const § = §;\n", g.ind(), pattern.alias, discriminant)
+    }
+    # Positional bindings: casu Click pro a, b
+    sin pattern.vincula.longitudo() > 0 {
+        result = scriptum("§const { § } = §;\n", g.ind(), pattern.vincula.coniunge(", "), discriminant)
     }
 
     redde result

--- a/fons/rivus/codegen/ts/sententia/index.fab
+++ b/fons/rivus/codegen/ts/sententia/index.fab
@@ -130,7 +130,7 @@ functio genSententiaContent(Sententia stmt, TsGenerator g) -> textus {
         }
 
         casu DiscerneSententia ut s {
-            redde genDiscerne(s.discriminans, s.casus qua lista<VariansCasus>, g)
+            redde genDiscerne(s.discriminantes, s.casus qua lista<VariansCasus>, g)
         }
 
         casu CustodiSententia ut s {

--- a/fons/rivus/parser/sententia/fluxus.fab
+++ b/fons/rivus/parser/sententia/fluxus.fab
@@ -16,9 +16,10 @@
 # - custodi = guard (imperative of custodire)
 
 ex "../resolvitor" importa Resolvitor
+ex "../nucleus" importa Parser
 ex "../../ast/positio" importa Locus
 ex "../../ast/expressia" importa Expressia
-ex "../../ast/sententia" importa Sententia, EligeCasus, VariansCasus, CustodiClausula, CapeClausula
+ex "../../ast/sententia" importa Sententia, EligeCasus, VariansCasus, VariansExemplar, CustodiClausula, CapeClausula
 ex "../../ast/lexema" importa SymbolumGenus
 ex "../errores" importa ParserErrorCodice
 ex "./massa" importa parseMassaSententia
@@ -112,14 +113,25 @@ functio parseEligeSententia(Resolvitor r) -> Sententia {
 # Parse discerne (pattern match) statement
 #
 # GRAMMAR:
-#   discerneStmt := 'discerne' expr '{' variantCase* '}'
-#   variantCase := 'casu' IDENT ('pro' IDENT (',' IDENT)*)? block
+#   discerneStmt := 'discerne' discriminants '{' variantCase* '}'
+#   discriminants := expression (',' expression)*
+#   variantCase := 'casu' patterns (block | 'ergo' stmt | 'reddit' expr)
+#   patterns := pattern (',' pattern)*
+#   pattern := '_' | (IDENTIFIER patternBind?)
+#   patternBind := ('ut' IDENTIFIER) | ('pro' IDENTIFIER (',' IDENTIFIER)*)
 #
 # Examples:
+#   # Single discriminant
 #   discerne event {
 #       casu Click pro x, y { scribe scriptum("clicked at §, §", x, y) }
 #       casu Keypress ut key { scribe scriptum("pressed §", key) }
 #       casu Quit { mori "goodbye" }
+#   }
+#
+#   # Multi-discriminant
+#   discerne left, right {
+#       casu Primitivum ut l, Primitivum ut r { redde l.nomen == r.nomen }
+#       casu _, _ { redde falsum }
 #   }
 @ publica
 functio parseDiscerneSententia(Resolvitor r) -> Sententia {
@@ -129,8 +141,12 @@ functio parseDiscerneSententia(Resolvitor r) -> Sententia {
     # Consume 'discerne'
     p.expectaVerbum("discerne", ParserErrorCodice.ExpectaturDiscerne)
 
-    # Parse discriminant expression
-    fixum discriminans = r.expressia()
+    # Parse comma-separated discriminants
+    varia discriminantes = [] innatum lista<Expressia>
+    discriminantes.adde(r.expressia())
+    dum p.congruet(SymbolumGenus.Coma) {
+        discriminantes.adde(r.expressia())
+    }
 
     # Expect opening brace
     p.expecta(SymbolumGenus.UncusSin, ParserErrorCodice.ExpectaturUncusSin)
@@ -143,24 +159,11 @@ functio parseDiscerneSententia(Resolvitor r) -> Sententia {
             fixum casusLocus = p.locusActualis()
             p.procede()  # Consume 'casu'
 
-            # Parse variant name
-            fixum variansNomenSym = p.expectaNomenAutVerbum(ParserErrorCodice.ExpectaturNomen)
-            fixum variansNomen = variansNomenSym.valor
-
-            # Parse optional bindings: ut alias OR pro x, y, z
-            # WHY: 'ut' binds the whole variant, 'pro' binds fields positionally.
-            varia alias = nihil qua textus?
-            varia vincula = [] innatum lista<textus>
-            si p.probaVerbum("ut") {
-                p.procede()
-                fixum aliasSym = p.expectaNomenAutVerbum(ParserErrorCodice.ExpectaturNomen)
-                alias = aliasSym.valor
-            } sin p.probaVerbum("pro") {
-                p.procede()
-                fac {
-                    fixum vincSym = p.expectaNomenAutVerbum(ParserErrorCodice.ExpectaturNomen)
-                    vincula.adde(vincSym.valor)
-                } dum p.congruet(SymbolumGenus.Coma)
+            # Parse comma-separated patterns (one per discriminant)
+            varia exemplaria = [] innatum lista<VariansExemplar>
+            exemplaria.adde(parseVariansExemplar(p))
+            dum p.congruet(SymbolumGenus.Coma) {
+                exemplaria.adde(parseVariansExemplar(p))
             }
 
             # Parse body
@@ -168,9 +171,7 @@ functio parseDiscerneSententia(Resolvitor r) -> Sententia {
 
             casus.adde({
                 locus: casusLocus,
-                variansNomen: variansNomen,
-                alias: alias,
-                vincula: vincula,
+                exemplaria: exemplaria,
                 consequens: consequens
             } qua VariansCasus)
         } secus {
@@ -183,9 +184,107 @@ functio parseDiscerneSententia(Resolvitor r) -> Sententia {
 
     redde finge DiscerneSententia {
         locus: locus,
-        discriminans: discriminans,
+        discriminantes: discriminantes,
         casus: casus
     } qua Sententia
+}
+
+# Parse a single variant pattern
+#
+# GRAMMAR:
+#   pattern := '_' | (IDENTIFIER patternBind?)
+#   patternBind := ('ut' IDENTIFIER) | ('pro' IDENTIFIER (',' IDENTIFIER)*)
+#
+# DISAMBIGUATION: After 'pro', commas separate bindings until we see:
+#   - '_' (wildcard pattern)
+#   - An identifier followed by 'ut' or 'pro' (new pattern with binding)
+#   - '{', 'ergo', 'reddit' (end of patterns)
+functio parseVariansExemplar(Parser p) -> VariansExemplar {
+    fixum locus = p.locusActualis()
+
+    # Parse variant name (or wildcard)
+    fixum variansNomenSym = p.expectaNomenAutVerbum(ParserErrorCodice.ExpectaturNomen)
+    fixum variansNomen = variansNomenSym.valor
+
+    # Check for wildcard
+    si variansNomen == "_" {
+        redde {
+            locus: locus,
+            variansNomen: "_",
+            estWildcard: verum,
+            alias: nihil qua textus?,
+            vincula: [] innatum lista<textus>
+        } qua VariansExemplar
+    }
+
+    # Parse optional bindings: ut alias OR pro x, y, z
+    # WHY: 'ut' binds the whole variant, 'pro' binds fields positionally.
+    varia alias = nihil qua textus?
+    varia vincula = [] innatum lista<textus>
+
+    si p.probaVerbum("ut") {
+        p.procede()
+        fixum aliasSym = p.expectaNomenAutVerbum(ParserErrorCodice.ExpectaturNomen)
+        alias = aliasSym.valor
+    } sin p.probaVerbum("pro") {
+        p.procede()
+        fac {
+            fixum vincSym = p.expectaNomenAutVerbum(ParserErrorCodice.ExpectaturNomen)
+            vincula.adde(vincSym.valor)
+        } dum estProximumVinculum(p)
+    }
+
+    redde {
+        locus: locus,
+        variansNomen: variansNomen,
+        estWildcard: falsum,
+        alias: alias,
+        vincula: vincula
+    } qua VariansExemplar
+}
+
+# Check if the token after a comma is a binding (not a new pattern)
+#
+# WHY: In multi-discriminant patterns, commas separate both:
+#   - Bindings within 'pro': `casu Click pro x, y { ... }`
+#   - Patterns: `casu Click ut c, Quit { ... }`
+#
+# RULE: After comma, it's a new pattern ONLY if:
+#   - Next token is '_' (wildcard)
+#   - Next token is identifier followed by 'ut' or 'pro' (pattern with binding)
+# Otherwise it's another binding.
+functio estProximumVinculum(Parser p) -> bivalens {
+    # Must be at comma to continue
+    si non p.proba(SymbolumGenus.Coma) {
+        redde falsum
+    }
+
+    fixum proximum = p.specta(1)
+
+    # Comma followed by '_' is next pattern (wildcard)
+    si proximum.species == SymbolumGenus.Nomen et proximum.valor == "_" {
+        redde falsum
+    }
+
+    # Comma followed by non-identifier is not a binding
+    si proximum.species != SymbolumGenus.Nomen et proximum.species != SymbolumGenus.Verbum {
+        redde falsum
+    }
+
+    # Look at what follows the identifier
+    fixum postIdent = p.specta(2)
+
+    # If followed by 'ut' or 'pro', it's a new pattern with binding
+    si postIdent.species == SymbolumGenus.Verbum {
+        si postIdent.valor == "ut" aut postIdent.valor == "pro" {
+            redde falsum
+        }
+    }
+
+    # Otherwise assume it's a binding (including when followed by ',', '{', 'ergo', 'reddit')
+    # Consume the comma and return true to continue the binding loop
+    p.procede()
+    redde verum
 }
 
 # ============================================================================

--- a/fons/rivus/semantic/sententia/imperium.fab
+++ b/fons/rivus/semantic/sententia/imperium.fab
@@ -179,34 +179,45 @@ functio analyzeDiscerne(Resolvitor r, Sententia discerneStmt) -> vacuum {
 
     discerne discerneStmt {
         casu DiscerneSententia ut d {
-            # Analyze discriminant
-            fixum discTypus = r.expressia(d.discriminans)
+            # Analyze all discriminants
+            ex d.discriminantes pro disc {
+                r.expressia(disc)
+            }
 
             # Analyze each variant case
             ex d.casus pro casus {
                 # Enter scope for pattern bindings
                 a.intraScopum(ScopusSpecies.Massa)
 
-                # Define bound variables if present
-                # WHY: 'ut' introduces an alias, 'pro' introduces field bindings.
-                si nonnihil casus.alias {
-                    fixum alias = casus.alias qua textus
-                    a.scopus.symbola[alias] = {
-                        nomen: alias,
-                        semanticTypus: IGNOTUM,  # TODO: infer from variant
-                        species: SymbolumSpecies.Variabilis,
-                        mutabilis: falsum,
-                        locus: casus.locus
+                # Define bound variables for all patterns in this case
+                # WHY: Each pattern can introduce 'ut' alias or 'pro' field bindings.
+                ex casus.exemplaria pro pattern {
+                    # Skip wildcards - they have no bindings
+                    si pattern.estWildcard {
+                        perge
                     }
-                }
 
-                ex casus.vincula pro vinculum {
-                    a.scopus.symbola[vinculum] = {
-                        nomen: vinculum,
-                        semanticTypus: IGNOTUM,  # TODO: infer from variant
-                        species: SymbolumSpecies.Variabilis,
-                        mutabilis: falsum,
-                        locus: casus.locus
+                    # Define alias if present
+                    si nonnihil pattern.alias {
+                        fixum alias = pattern.alias qua textus
+                        a.scopus.symbola[alias] = {
+                            nomen: alias,
+                            semanticTypus: IGNOTUM,  # TODO: infer from variant
+                            species: SymbolumSpecies.Variabilis,
+                            mutabilis: falsum,
+                            locus: pattern.locus
+                        }
+                    }
+
+                    # Define field bindings if present
+                    ex pattern.vincula pro vinculum {
+                        a.scopus.symbola[vinculum] = {
+                            nomen: vinculum,
+                            semanticTypus: IGNOTUM,  # TODO: infer from variant
+                            species: SymbolumSpecies.Variabilis,
+                            mutabilis: falsum,
+                            locus: pattern.locus
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary

- Implements multi-discriminant pattern matching syntax in the rivus bootstrap compiler
- Adds `VariansExemplar` type for individual patterns in the AST
- Updates parser to handle comma-separated discriminants and patterns with proper disambiguation
- Updates TypeScript codegen to generate combined conditions for multiple discriminants
- Updates semantic analyzer to handle multiple discriminants and pattern bindings

Fixes #48

## Test plan

- [x] `bun run build:rivus` succeeds (was previously failing on `typi.fab:229`)
- [x] Multi-discriminant discerne tests pass: `bun test -t "two discriminants"`
- [x] Mixed wildcard pattern tests pass: `bun test -t "mixed wildcard"`
- [x] Single binding tests pass: `bun test -t "single binding"`
- [x] All rivus discerne tests pass (except pre-existing S017 exhaustiveness checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)