### PR TITLE
Fix rivus semantic: resolve ignotum type annotation to Ignotum variant

### DIFF
--- a/fons/rivus/semantic/sententia/declara.fab
+++ b/fons/rivus/semantic/sententia/declara.fab
@@ -4,7 +4,7 @@
 
 ex "../resolvitor" importa Resolvitor
 ex "../typi" importa SemanticTypus, VACUUM, IGNOTUM, NIHIL, NUMERUS
-ex "../typi" importa primitivumTypus, genericumTypus, unioTypus
+ex "../typi" importa primitivumTypus, genericumTypus, unioTypus, ignotumTypus
 ex "../typi" importa functioTypus, usitatumTypus, genusTypus, pactumTypus, ordoTypus
 ex "../typi" importa formaTypum, assignabileAd
 ex "../scopus" importa Symbolum, SymbolumSpecies, ScopusSpecies, quaereSymbolumLocale
@@ -48,6 +48,14 @@ functio resolveTypusAnnotatio(Resolvitor r, TypusAnnotatio annotatio) -> Semanti
 
     si estGenericusTypus(annotatio.nomen) {
         redde genericumTypus(annotatio.nomen, resolvedParametri, annotatio.nullabilis)
+    }
+
+    # Handle ignotum specially - returns Ignotum variant, not a primitive
+    si annotatio.nomen == "ignotum" {
+        si annotatio.nullabilis {
+            redde unioTypus([ignotumTypus(nihil), NIHIL])
+        }
+        redde ignotumTypus(nihil)
     }
 
     # Primitive types


### PR DESCRIPTION
## Summary

- Add special handling for `ignotum` type annotation in `resolveTypusAnnotatio`
- Non-nullable `ignotum` returns `Ignotum{}` variant instead of `Usitatum{nomen: "ignotum"}`
- Nullable `ignotum?` returns union of `[Ignotum, NIHIL]`

## Test plan

- [x] Verify `bun run faber check fons/rivus/semantic/sententia/declara.fab` passes
- [x] Verify `bun run build:rivus` completes successfully
- [x] Verify tests pass (pre-existing failures unrelated to this change)

Fixes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)