### PR TITLE
Fix TypeScript error: pactum methods map type

### DIFF
--- a/fons/faber/semantic/modules.ts
+++ b/fons/faber/semantic/modules.ts
@@ -375,7 +375,7 @@ function extractGenusExport(stmt: GenusDeclaration, ctx: ModuleTypeContext): Mod
  * fails because the return type can't be resolved.
  */
 function extractPactumExport(stmt: PactumDeclaration, ctx: ModuleTypeContext): ModuleExport {
-    const methods = new Map<string, SemanticType>();
+    const methods = new Map<string, FunctionType>();
 
     for (const method of stmt.methods) {
         const paramTypes = method.params.map(p =>


### PR DESCRIPTION
## Summary
- Fix TS2345 type error in `extractPactumExport` function in `fons/faber/semantic/modules.ts`
- The `methods` map was typed as `Map<string, SemanticType>` but populated with `FunctionType` values
- Changed to `Map<string, FunctionType>` to match both the values being stored and the signature of `pactumType()`

## Test plan
- [x] Run `bun run typecheck` - passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)