### PR TITLE
Emit export keyword for public declarations in rivus codegen

### DIFF
--- a/fons/rivus/ast/sententia.fab
+++ b/fons/rivus/ast/sententia.fab
@@ -281,6 +281,7 @@ discretio Sententia {
         TypusAnnotatio? typus
         Expressia? valor
         bivalens externa        # @ externa annotation
+        Visibilitas? visibilitas  # @ publica annotation for module-level export
     }
 
     # Import declaration
@@ -352,6 +353,7 @@ discretio Sententia {
         Sententia? structor      # FunctioDeclaratio (WHY: "constructor" is JS reserved)
         lista<Sententia> methodi # lista<FunctioDeclaratio>
         MorphologiaDeclaratio? morphologia
+        Visibilitas? visibilitas  # @ publica annotation for module-level export
     }
 
     # Pactum (interface) declaration
@@ -361,6 +363,7 @@ discretio Sententia {
         textus nomen
         lista<textus>? generaParametra
         lista<PactumMethodus> methodi
+        Visibilitas? visibilitas  # @ publica annotation for module-level export
     }
 
     # Type alias declaration
@@ -370,6 +373,7 @@ discretio Sententia {
         textus nomen
         TypusAnnotatio typus
         textus? scopusNomen      # for typeof: typus X = typus y
+        Visibilitas? visibilitas  # @ publica annotation for module-level export
     }
 
     # Ordo (enum) declaration
@@ -378,6 +382,7 @@ discretio Sententia {
         Locus locus
         textus nomen
         lista<OrdoMembrum> membra
+        Visibilitas? visibilitas  # @ publica annotation for module-level export
     }
 
     # Discretio (tagged union) declaration
@@ -387,6 +392,7 @@ discretio Sententia {
         textus nomen
         lista<textus>? generaParametra
         lista<VariansDeclaratio> variantes
+        Visibilitas? visibilitas  # @ publica annotation for module-level export
     }
 
     # -------------------------------------------------------------------------

--- a/fons/rivus/codegen/ts/sententia/discretio.fab
+++ b/fons/rivus/codegen/ts/sententia/discretio.fab
@@ -4,14 +4,24 @@
 #
 # TRANSFORMS:
 #   discretio Result { Ok, Err } -> type Result = { tag: 'Ok'; ... } | { tag: 'Err'; ... }
+#   @ publica discretio X { ... } -> export type X = ...
 
-ex "../../../ast/sententia" importa VariansDeclaratio
+ex "../../../ast/sententia" importa VariansDeclaratio, Visibilitas
 ex "../nucleus" importa TsGenerator
 ex "../typus" importa genTypus
 
 @ publica
-functio genDiscretio(textus nomen, ignotum generaParametra, lista<VariansDeclaratio> variantes, TsGenerator g) -> textus {
+functio genDiscretio(textus nomen, ignotum generaParametra, lista<VariansDeclaratio> variantes, ignotum visibilitas, TsGenerator g) -> textus {
     # TS: prefer inline union members so tests can match exact fragments.
+
+    # Module-level: export when public
+    varia exportPrefix = ""
+    si nonnihil visibilitas {
+        fixum vis = visibilitas qua Visibilitas
+        si vis == Visibilitas.Publica {
+            exportPrefix = "export "
+        }
+    }
 
     varia params = ""
     si nonnihil generaParametra {
@@ -29,5 +39,5 @@ functio genDiscretio(textus nomen, ignotum generaParametra, lista<VariansDeclara
         variants.adde(member)
     }
 
-    redde scriptum("§type §§ = §;", g.ind(), nomen, params, variants.coniunge(" | "))
+    redde scriptum("§§type §§ = §;", g.ind(), exportPrefix, nomen, params, variants.coniunge(" | "))
 }

--- a/fons/rivus/codegen/ts/sententia/functio.fab
+++ b/fons/rivus/codegen/ts/sententia/functio.fab
@@ -86,7 +86,7 @@ functio genFunctio(textus nomen, ignotum generaParametra, lista<Parametrum> para
         localGenerator = verum
     }
 
-    # Visibility and abstract modifier (class methods only)
+    # Visibility: class methods get public/private/protected, module-level gets export
     si g.inGenere et non structor {
         si nonnihil visibilitas {
             fixum vis = visibilitas qua Visibilitas
@@ -100,6 +100,14 @@ functio genFunctio(textus nomen, ignotum generaParametra, lista<Parametrum> para
         }
         si abstracta {
             result = scriptum("§abstract ", result)
+        }
+    } secus {
+        # Module-level: export when public
+        si nonnihil visibilitas {
+            fixum vis = visibilitas qua Visibilitas
+            si vis == Visibilitas.Publica {
+                result = scriptum("§export ", result)
+            }
         }
     }
 

--- a/fons/rivus/codegen/ts/sententia/genus.fab
+++ b/fons/rivus/codegen/ts/sententia/genus.fab
@@ -8,6 +8,7 @@
 #   genus Foo extendit Bar { ... }  -> class Foo extends Bar { ... }
 #   genus Foo implet X, Y { ... }   -> class Foo implements X, Y { ... }
 #   @ abstractum genus Foo { ... }  -> abstract class Foo { ... }
+#   @ publica genus Foo { ... }     -> export class Foo { ... }
 #   campus publicus x: numerus      -> public x: number
 #   campus staticus x: numerus      -> static x: number
 
@@ -22,8 +23,16 @@ ex "./index" importa genSententia
 ex "../typus" importa genTypus
 
 @ publica
-functio genGenus(textus nomen, ignotum generaParametra, ignotum extendit, ignotum implet, bivalens abstractum, lista<CampusDeclaratio> campi, ignotum structor, lista<Sententia> methodi, TsGenerator g) -> textus {
+functio genGenus(textus nomen, ignotum generaParametra, ignotum extendit, ignotum implet, bivalens abstractum, lista<CampusDeclaratio> campi, ignotum structor, lista<Sententia> methodi, ignotum visibilitas, TsGenerator g) -> textus {
     varia result = g.ind()
+
+    # Module-level: export when public
+    si nonnihil visibilitas {
+        fixum vis = visibilitas qua Visibilitas
+        si vis == Visibilitas.Publica {
+            result = scriptum("§export ", result)
+        }
+    }
 
     si abstractum {
         result = scriptum("§abstract ", result)

--- a/fons/rivus/codegen/ts/sententia/index.fab
+++ b/fons/rivus/codegen/ts/sententia/index.fab
@@ -67,7 +67,7 @@ functio genSententiaContent(Sententia stmt, TsGenerator g) -> textus {
 
         # Variable declarations
         casu VariaSententia ut s {
-            redde genVaria(s.species qua VariaGenus, s.nomen qua textus, s.typus, s.valor, s.externa qua bivalens, g)
+            redde genVaria(s.species qua VariaGenus, s.nomen qua textus, s.typus, s.valor, s.externa qua bivalens, s.visibilitas, g)
         }
 
         casu ImportaSententia ut s {
@@ -89,23 +89,23 @@ functio genSententiaContent(Sententia stmt, TsGenerator g) -> textus {
 
         # Type declarations
         casu GenusDeclaratio ut s {
-            redde genGenus(s.nomen qua textus, s.generaParametra, s.extendit, s.implet, s.abstractum qua bivalens, s.campi qua lista<CampusDeclaratio>, s.structor, s.methodi qua lista<Sententia>, g)
+            redde genGenus(s.nomen qua textus, s.generaParametra, s.extendit, s.implet, s.abstractum qua bivalens, s.campi qua lista<CampusDeclaratio>, s.structor, s.methodi qua lista<Sententia>, s.visibilitas, g)
         }
 
         casu PactumDeclaratio ut s {
-            redde genPactum(s.nomen qua textus, s.generaParametra, s.methodi qua lista<PactumMethodus>, g)
+            redde genPactum(s.nomen qua textus, s.generaParametra, s.methodi qua lista<PactumMethodus>, s.visibilitas, g)
         }
 
         casu TypusAliasDeclaratio ut s {
-            redde genTypusAlias(s.nomen qua textus, s.typus qua TypusAnnotatio, s.scopusNomen, g)
+            redde genTypusAlias(s.nomen qua textus, s.typus qua TypusAnnotatio, s.scopusNomen, s.visibilitas, g)
         }
 
         casu OrdoDeclaratio ut s {
-            redde genOrdo(s.nomen qua textus, s.membra qua lista<OrdoMembrum>, g)
+            redde genOrdo(s.nomen qua textus, s.membra qua lista<OrdoMembrum>, s.visibilitas, g)
         }
 
         casu DiscretioDeclaratio ut s {
-            redde genDiscretio(s.nomen qua textus, s.generaParametra, s.variantes qua lista<VariansDeclaratio>, g)
+            redde genDiscretio(s.nomen qua textus, s.generaParametra, s.variantes qua lista<VariansDeclaratio>, s.visibilitas, g)
         }
 
         # Control flow

--- a/fons/rivus/codegen/ts/sententia/ordo.fab
+++ b/fons/rivus/codegen/ts/sententia/ordo.fab
@@ -5,13 +5,24 @@
 # TRANSFORMS:
 #   ordo Color { Red, Green, Blue }          -> enum Color { Red, Green, Blue }
 #   ordo Status { Active = 1, Inactive = 0 } -> enum Status { Active = 1, Inactive = 0 }
+#   @ publica ordo Color { ... }             -> export enum Color { ... }
 
-ex "../../../ast/sententia" importa OrdoMembrum
+ex "../../../ast/sententia" importa OrdoMembrum, Visibilitas
 ex "../nucleus" importa TsGenerator
 
 @ publica
-functio genOrdo(textus nomen, lista<OrdoMembrum> membra, TsGenerator g) -> textus {
-    varia result = scriptum("§enum § {\n", g.ind(), nomen)
+functio genOrdo(textus nomen, lista<OrdoMembrum> membra, ignotum visibilitas, TsGenerator g) -> textus {
+    varia result = g.ind()
+
+    # Module-level: export when public
+    si nonnihil visibilitas {
+        fixum vis = visibilitas qua Visibilitas
+        si vis == Visibilitas.Publica {
+            result = scriptum("§export ", result)
+        }
+    }
+
+    result = scriptum("§enum § {\n", result, nomen)
     g.intraProfundum()
 
     # If no member has an explicit value, keep them on one line.

--- a/fons/rivus/codegen/ts/sententia/pactum.fab
+++ b/fons/rivus/codegen/ts/sententia/pactum.fab
@@ -8,8 +8,9 @@
 #   pactum Foo { f(): T }         -> interface Foo { f(): T }
 #   pactum Foo { futura f(): T }  -> interface Foo { f(): Promise<T> }
 #   pactum Foo { cursore f(): T } -> interface Foo { f(): Generator<T> }
+#   @ publica pactum Foo { ... }  -> export interface Foo { ... }
 
-ex "../../../ast/sententia" importa Parametrum, PactumMethodus
+ex "../../../ast/sententia" importa Parametrum, PactumMethodus, Visibilitas
 ex "../../../ast/typus" importa TypusAnnotatio
 ex "../nucleus" importa TsGenerator
 
@@ -18,8 +19,18 @@ ex "./functio" importa genParametrum
 ex "../typus" importa genTypus
 
 @ publica
-functio genPactum(textus nomen, ignotum generaParametra, lista<PactumMethodus> methodi, TsGenerator g) -> textus {
-    varia result = scriptum("§interface §", g.ind(), nomen)
+functio genPactum(textus nomen, ignotum generaParametra, lista<PactumMethodus> methodi, ignotum visibilitas, TsGenerator g) -> textus {
+    varia result = g.ind()
+
+    # Module-level: export when public
+    si nonnihil visibilitas {
+        fixum vis = visibilitas qua Visibilitas
+        si vis == Visibilitas.Publica {
+            result = scriptum("§export ", result)
+        }
+    }
+
+    result = scriptum("§interface §", result, nomen)
 
     si nonnihil generaParametra {
         fixum gp = generaParametra qua lista<textus>

--- a/fons/rivus/codegen/ts/sententia/typealias.fab
+++ b/fons/rivus/codegen/ts/sententia/typealias.fab
@@ -5,17 +5,28 @@
 # TRANSFORMS:
 #   typus Foo = textus     -> type Foo = string
 #   typus Foo = typeof Bar -> type Foo = typeof Bar
+#   @ publica typus X = Y  -> export type X = Y
 
 ex "../../../ast/typus" importa TypusAnnotatio
+ex "../../../ast/sententia" importa Visibilitas
 ex "../nucleus" importa TsGenerator
 
 # External declarations - implementations live in index.fab
 ex "../typus" importa genTypus
 
 @ publica
-functio genTypusAlias(textus nomen, TypusAnnotatio adnotatioTypus, ignotum scopusNomen, TsGenerator g) -> textus {
-    si nonnihil scopusNomen {
-        redde scriptum("§type § = typeof §;", g.ind(), nomen, scopusNomen qua textus)
+functio genTypusAlias(textus nomen, TypusAnnotatio adnotatioTypus, ignotum scopusNomen, ignotum visibilitas, TsGenerator g) -> textus {
+    # Module-level: export when public
+    varia exportPrefix = ""
+    si nonnihil visibilitas {
+        fixum vis = visibilitas qua Visibilitas
+        si vis == Visibilitas.Publica {
+            exportPrefix = "export "
+        }
     }
-    redde scriptum("§type § = §;", g.ind(), nomen, genTypus(adnotatioTypus, g))
+
+    si nonnihil scopusNomen {
+        redde scriptum("§§type § = typeof §;", g.ind(), exportPrefix, nomen, scopusNomen qua textus)
+    }
+    redde scriptum("§§type § = §;", g.ind(), exportPrefix, nomen, genTypus(adnotatioTypus, g))
 }

--- a/fons/rivus/codegen/ts/sententia/varia.fab
+++ b/fons/rivus/codegen/ts/sententia/varia.fab
@@ -4,8 +4,9 @@
 #   varia x: numerus = 5      -> let x: number = 5
 #   fixum y: textus = "hello" -> const y: string = "hello"
 #   @ externa fixum z: numerus -> declare const z: number
+#   @ publica fixum x = 1     -> export const x = 1
 
-ex "../../../ast/sententia" importa VariaGenus
+ex "../../../ast/sententia" importa VariaGenus, Visibilitas
 ex "../../../ast/expressia" importa Expressia
 ex "../../../ast/typus" importa TypusAnnotatio
 ex "../nucleus" importa TsGenerator
@@ -13,7 +14,7 @@ ex "../typus" importa genTypus
 ex "../expressia/index" importa genExpressia
 
 @ publica
-functio genVaria(VariaGenus species, textus nomen, ignotum adnotatioTypus, ignotum valor, bivalens externa, TsGenerator g) -> textus {
+functio genVaria(VariaGenus species, textus nomen, ignotum adnotatioTypus, ignotum valor, bivalens externa, ignotum visibilitas, TsGenerator g) -> textus {
     # External declarations use TypeScript's 'declare' syntax
     si externa {
         varia result = scriptum("§declare const §", g.ind(), nomen)
@@ -26,7 +27,16 @@ functio genVaria(VariaGenus species, textus nomen, ignotum adnotatioTypus, ignot
     fixum keyword = species == VariaGenus.Fixum aut species == VariaGenus.Figendum sic "const" secus "let"
     fixum asyncPrefix = species == VariaGenus.Figendum aut species == VariaGenus.Variandum sic "await " secus ""
 
-    varia result = scriptum("§§ §", g.ind(), keyword, nomen)
+    # Module-level: export when public (not inside class)
+    varia exportPrefix = ""
+    si non g.inGenere et nonnihil visibilitas {
+        fixum vis = visibilitas qua Visibilitas
+        si vis == Visibilitas.Publica {
+            exportPrefix = "export "
+        }
+    }
+
+    varia result = scriptum("§§§ §", g.ind(), exportPrefix, keyword, nomen)
 
     si nonnihil adnotatioTypus {
         result = scriptum("§: §", result, genTypus(adnotatioTypus qua TypusAnnotatio, g))

--- a/fons/rivus/parser/sententia/declara.fab
+++ b/fons/rivus/parser/sententia/declara.fab
@@ -330,7 +330,8 @@ functio parseGenusDeclaratio(Resolvitor r, bivalens abstractum) -> Sententia {
         campi: campi,
         structor: structor,
         methodi: methodi,
-        morphologia: nihil
+        morphologia: nihil,
+        visibilitas: nihil
     } qua Sententia
 }
 
@@ -428,7 +429,8 @@ functio parsePactumDeclaratio(Resolvitor r) -> Sententia {
         locus: locus,
         nomen: nomen,
         generaParametra: generaParametra,
-        methodi: methodi
+        methodi: methodi,
+        visibilitas: nihil
     } qua Sententia
 }
 
@@ -497,7 +499,8 @@ functio parseOrdoDeclaratio(Resolvitor r) -> Sententia {
     redde finge OrdoDeclaratio {
         locus: locus,
         nomen: nomen,
-        membra: membra
+        membra: membra,
+        visibilitas: nihil
     } qua Sententia
 }
 
@@ -600,7 +603,8 @@ functio parseDiscretioDeclaratio(Resolvitor r) -> Sententia {
         locus: locus,
         nomen: nomen,
         generaParametra: generaParametra,
-        variantes: variantes
+        variantes: variantes,
+        visibilitas: nihil
     } qua Sententia
 }
 
@@ -654,7 +658,8 @@ functio parseTypusAliasDeclaratio(Resolvitor r) -> Sententia {
         locus: locus,
         nomen: nomen,
         typus: typusAlias,
-        scopusNomen: scopusNomen
+        scopusNomen: scopusNomen,
+        visibilitas: nihil
     } qua Sententia
 }
 

--- a/fons/rivus/parser/sententia/index.fab
+++ b/fons/rivus/parser/sententia/index.fab
@@ -16,7 +16,7 @@
 ex "../resolvitor" importa Resolvitor
 ex "../../ast/positio" importa Locus
 ex "../../ast/expressia" importa Expressia
-ex "../../ast/sententia" importa Sententia, ScribeGradus, MorphologiaDeclaratio
+ex "../../ast/sententia" importa Sententia, ScribeGradus, MorphologiaDeclaratio, Visibilitas
 ex "../../ast/lexema" importa SymbolumGenus, VerbumId
 ex "../../ast/radix" importa NodusRadix
 ex "../errores" importa ParserErrorCodice
@@ -66,6 +66,16 @@ functio parseSententiaSineNotis(Resolvitor r) -> Sententia {
         fixum stmt = parseSententiaSineNotis(r)
 
         ex annotationes pro a {
+            # Check for visibility annotations
+            varia visibilitas = nihil qua Visibilitas?
+            si a.nomen inter ["publicum", "publica", "publicus"] {
+                visibilitas = Visibilitas.Publica
+            } sin a.nomen inter ["protectum", "protecta", "protectus"] {
+                visibilitas = Visibilitas.Protecta
+            } sin a.nomen inter ["privatum", "privata", "privatus"] {
+                visibilitas = Visibilitas.Privata
+            }
+
             discerne stmt {
                 casu FunctioDeclaratio ut f {
                     si a.nomen == "futura" {
@@ -77,15 +87,44 @@ functio parseSententiaSineNotis(Resolvitor r) -> Sententia {
                     si a.nomen == "externa" {
                         f.externa = verum
                     }
+                    si nonnihil visibilitas {
+                        f.visibilitas = visibilitas
+                    }
                 }
                 casu VariaSententia ut v {
                     si a.nomen == "externa" {
                         v.externa = verum
                     }
+                    si nonnihil visibilitas {
+                        v.visibilitas = visibilitas
+                    }
                 }
                 casu GenusDeclaratio ut g {
                     si a.nomen inter ["abstractum", "abstracta", "abstractus"] {
                         g.abstractum = verum
+                    }
+                    si nonnihil visibilitas {
+                        g.visibilitas = visibilitas
+                    }
+                }
+                casu PactumDeclaratio ut p {
+                    si nonnihil visibilitas {
+                        p.visibilitas = visibilitas
+                    }
+                }
+                casu OrdoDeclaratio ut o {
+                    si nonnihil visibilitas {
+                        o.visibilitas = visibilitas
+                    }
+                }
+                casu DiscretioDeclaratio ut d {
+                    si nonnihil visibilitas {
+                        d.visibilitas = visibilitas
+                    }
+                }
+                casu TypusAliasDeclaratio ut t {
+                    si nonnihil visibilitas {
+                        t.visibilitas = visibilitas
                     }
                 }
                 casu _ { }

--- a/fons/rivus/parser/sententia/varia.fab
+++ b/fons/rivus/parser/sententia/varia.fab
@@ -245,6 +245,7 @@ functio parseVariaSententia(Resolvitor r) -> Sententia {
         nomen: nomen,
         typus: adnotatio,
         valor: valor,
-        externa: falsum
+        externa: falsum,
+        visibilitas: nihil
     } qua Sententia
 }


### PR DESCRIPTION
## Summary

- Adds `visibilitas` field to AST declaration types (VariaSententia, GenusDeclaratio, PactumDeclaratio, OrdoDeclaratio, DiscretioDeclaratio, TypusAliasDeclaratio)
- Updates parser to extract visibility from `@publica`/`@publicum` annotations
- Updates codegen generators to emit `export` prefix when visibility is public for module-level declarations

## Test plan

- [x] Build rivus with `bun run build:rivus` - passes
- [x] Verify generated TypeScript files contain `export` keywords for public declarations
- [x] Existing tests pass (no regressions introduced)

Fixes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)