### PR TITLE
Rename 'bootstrap' target to 'artifex'

### DIFF
--- a/fons/proba/rivus-compile.ts
+++ b/fons/proba/rivus-compile.ts
@@ -1,7 +1,7 @@
 /**
  * Isolated compiler runner for rivus tests.
  *
- * Runs the bootstrap compiler (opus/bootstrap) in a separate process so the
+ * Runs the bootstrap compiler (opus/rivus) in a separate process so the
  * test harness can enforce hard timeouts even if the parser hits a CPU-bound
  * infinite loop.
  *

--- a/fons/proba/rivus.test.ts
+++ b/fons/proba/rivus.test.ts
@@ -1,7 +1,7 @@
 /**
  * Test runner for rivus (bootstrap compiler).
  *
- * Runs YAML test cases through opus/bootstrap, TS target only.
+ * Runs YAML test cases through opus/rivus, TS target only.
  * Used to identify codegen gaps between faber and rivus.
  *
  * USAGE

--- a/fons/rivus/CHECKLIST.md
+++ b/fons/rivus/CHECKLIST.md
@@ -25,7 +25,7 @@ rivus compile <file.fab> -o out.ts    # Specify output file
 
 > Status % = passing tests / TypeScript baseline (741). Run `bun test proba/runner.test.ts -t "@rivus @<target>"` to verify. 35 tests skipped (intrinsic I/O functions, deferred).
 
-> **Bootstrap Status:** The bootstrap compiler (`bun run build:bootstrap`) is currently blocked by parser and semantic analyzer gaps. See issues #48 (multi-discriminant discerne), #49 (block scoping), #50 (member assignment), #51 (predeclaration types).
+> **Artifex Status:** The artifex compiler (`bun run build:artifex`) is currently blocked by parser and semantic analyzer gaps. See issues #48 (multi-discriminant discerne), #49 (block scoping), #50 (member assignment), #51 (predeclaration types).
 
 Status: ● implemented, ◐ partial, ○ not implemented, — not applicable, ◌ convention
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "build:faber": "bun ./scripta/build-faber.ts",
         "build:norma": "bun ./scripta/build-norma.ts",
         "build:rivus": "bun ./scripta/build-rivus.ts",
-        "build:bootstrap": "bun ./scripta/build-bootstrap.ts",
+        "build:artifex": "bun ./scripta/build-artifex.ts",
         "build:exempla": "bun ./scripta/build-exempla.ts",
         "build:exec": "bun ./scripta/build-exec.ts",
         "lint": "./scripta/lint",

--- a/scripta/build-artifex.ts
+++ b/scripta/build-artifex.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /**
- * Bootstrap test: Use rivus to compile itself
+ * Artifex test: Use rivus to compile itself
  *
  * Uses the compiled rivus executable (opus/bin/rivus) to compile
  * the rivus source files in fons/rivus/ and compare against
@@ -9,7 +9,7 @@
  * This proves rivus can self-host.
  *
  * Usage:
- *   bun scripta/build-bootstrap.ts
+ *   bun scripta/build-artifex.ts
  */
 
 import { Glob } from 'bun';
@@ -20,7 +20,7 @@ import { $ } from 'bun';
 const ROOT = join(import.meta.dir, '..');
 const SOURCE = join(ROOT, 'fons', 'rivus');
 const RIVUS_BIN = join(ROOT, 'opus', 'bin', 'rivus');
-const BOOTSTRAP_DIR = join(ROOT, 'opus', 'bootstrap', 'fons', 'ts');
+const ARTIFEX_DIR = join(ROOT, 'opus', 'artifex', 'fons', 'ts');
 const REFERENCE_DIR = join(ROOT, 'opus', 'rivus', 'fons', 'ts');
 
 interface CompileResult {
@@ -31,7 +31,7 @@ interface CompileResult {
 
 async function compileFile(fabPath: string): Promise<CompileResult> {
     const relPath = relative(SOURCE, fabPath);
-    const outPath = join(BOOTSTRAP_DIR, relPath.replace(/\.fab$/, '.ts'));
+    const outPath = join(ARTIFEX_DIR, relPath.replace(/\.fab$/, '.ts'));
 
     try {
         const source = await Bun.file(fabPath).text();
@@ -70,19 +70,19 @@ async function compileFile(fabPath: string): Promise<CompileResult> {
 }
 
 async function compareFiles(file: string): Promise<{ match: boolean; diff?: string }> {
-    const bootstrapPath = join(BOOTSTRAP_DIR, file.replace(/\.fab$/, '.ts'));
+    const artifexPath = join(ARTIFEX_DIR, file.replace(/\.fab$/, '.ts'));
     const referencePath = join(REFERENCE_DIR, file.replace(/\.fab$/, '.ts'));
 
     try {
-        const bootstrapContent = await Bun.file(bootstrapPath).text();
+        const artifexContent = await Bun.file(artifexPath).text();
         const referenceContent = await Bun.file(referencePath).text();
 
-        if (bootstrapContent === referenceContent) {
+        if (artifexContent === referenceContent) {
             return { match: true };
         }
 
         // Files differ - show diff
-        const diffProc = Bun.spawn(['diff', '-u', referencePath, bootstrapPath], {
+        const diffProc = Bun.spawn(['diff', '-u', referencePath, artifexPath], {
             stdout: 'pipe',
         });
         const diff = await new Response(diffProc.stdout).text();
@@ -103,7 +103,7 @@ async function main() {
         process.exit(1);
     }
 
-    console.log('Bootstrap test: compiling rivus with rivus\n');
+    console.log('Artifex test: compiling rivus with rivus\n');
 
     // Find all .fab files
     const glob = new Glob('**/*.fab');
@@ -154,7 +154,7 @@ async function main() {
     console.log(`OK (${matches} files match, ${compareElapsed.toFixed(0)}ms)`);
 
     const elapsed = performance.now() - start;
-    console.log(`\nBootstrap test passed! rivus successfully compiled itself (${(elapsed / 1000).toFixed(1)}s)`);
+    console.log(`\nArtifex test passed! rivus successfully compiled itself (${(elapsed / 1000).toFixed(1)}s)`);
 }
 
 main().catch(err => {

--- a/scripta/rivus-zig
+++ b/scripta/rivus-zig
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Compile Faber source to Zig using rivus bootstrap compiler
+# Compile Faber source to Zig using rivus artifex compiler
 # Usage: ./scripta/rivus-zig < input.fab > output.zig
 #        echo 'incipit { scribe "hello" }' | ./scripta/rivus-zig
 
@@ -7,9 +7,9 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 bun -e "
-import { lexare } from './opus/bootstrap/lexor/index.ts';
-import { resolvere } from './opus/bootstrap/parser/index.ts';
-import { generateZig } from './opus/bootstrap/codegen/zig/index.ts';
+import { lexare } from './opus/artifex/lexor/index.ts';
+import { resolvere } from './opus/artifex/parser/index.ts';
+import { generateZig } from './opus/artifex/codegen/zig/index.ts';
 
 const source = await Bun.stdin.text();
 const lexResult = lexare(source);

--- a/scripta/selfhost-rivus
+++ b/scripta/selfhost-rivus
@@ -5,7 +5,7 @@
 # Then uses stage1 to compile Rivus -> stage2, type-checks both, and diffs.
 #
 # Output layout:
-#   opus/bootstrap/        stage0 (built by `bun run build:rivus`)
+#   opus/artifex/          stage0 (built by `bun run build:rivus`)
 #   opus/rivus/stage1/     stage1 (compiled by stage0)
 #   opus/rivus/stage2/     stage2 (compiled by stage1)
 set -euo pipefail
@@ -15,7 +15,7 @@ cd "$(dirname "$0")/.."
 # WHY: Enable globstar for ** recursive matching
 shopt -s globstar
 
-stage0="opus/bootstrap/cli.ts"
+stage0="opus/artifex/cli.ts"
 stage1_dir="opus/rivus/stage1"
 stage2_dir="opus/rivus/stage2"
 


### PR DESCRIPTION
## Summary

- Renames the self-hosting compilation target from "bootstrap" to "artifex" (Latin: master craftsman)
- Updates all script references, paths, and documentation to use the new naming
- Preserves git history for the renamed file via `git mv`

This aligns with Faber's Latin naming convention: **faber** (craftsman) → **rivus** (stream) → **artifex** (master craftsman).

## Changes

| File | Change |
|------|--------|
| `scripta/build-bootstrap.ts` | Renamed to `build-artifex.ts`, updated constants |
| `package.json` | `build:bootstrap` → `build:artifex` |
| `scripta/selfhost-rivus` | Updated `opus/bootstrap/` → `opus/artifex/` |
| `scripta/rivus-zig` | Updated imports from `opus/bootstrap/` to `opus/artifex/` |
| `fons/rivus/CHECKLIST.md` | Updated command reference |
| `fons/proba/*.ts` | Fixed inaccurate path references in comments |

## Test plan

- [ ] Verify `bun run build:artifex` works (requires `bun run build:rivus` first)
- [ ] Verify `opus/artifex/` directory is created instead of `opus/bootstrap/`
- [ ] Verify no references to `opus/bootstrap/` remain in active scripts

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)