### PR TITLE
Fix Rivus adfirma codegen quote escaping bug

### DIFF
--- a/fons/rivus/codegen/ts/sententia/adfirma.fab
+++ b/fons/rivus/codegen/ts/sententia/adfirma.fab
@@ -21,7 +21,7 @@ functio genAdfirma(Expressia condicio, ignotum nuntius, TsGenerator g) -> textus
         nuntiusTextus = genExpressia(nuntius qua Expressia, g)
     } secus {
         # WHY: Auto-generate assertion message from expression.
-        nuntiusTextus = scriptum("\"Assertion failed: §\"", test.replace("\"", "\\\""))
+        nuntiusTextus = scriptum("\"Assertion failed: §\"", test.muta("\"", "\\\""))
     }
 
     redde scriptum("§if (!(§)) { throw new Error(§); }", g.ind(), test, nuntiusTextus)


### PR DESCRIPTION
## Summary
- Fixed quote escaping bug in Rivus TypeScript codegen for assertion statements
- Replaced `.replace()` with `.muta()` for global quote replacement
- Verified fix works correctly with generated code

## Test plan
- [x] Built Rivus compiler successfully with changes
- [x] Tested assertion code with quoted strings (`adfirma name == "Marcus"`)
- [x] Verified generated TypeScript has properly escaped quotes
- [x] Confirmed generated code executes without syntax errors
- [x] Audited codebase for similar `.replace()` usage patterns (none found)

Fixes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)