### PR TITLE
Fix fab codegen to output parseable Faber syntax

### DIFF
--- a/fons/faber/codegen/fab/expressions/binary.ts
+++ b/fons/faber/codegen/fab/expressions/binary.ts
@@ -1,16 +1,27 @@
 /**
  * Faber Code Generator - BinaryExpression
  *
- * BUG: Outputs operators as-is from AST. Should map to Faber canonical forms:
- *   && -> et, || -> aut, ! -> non
- * See issue #81 for full fab codegen fixes needed.
+ * Maps JavaScript operators to Faber canonical forms for parseable output.
  */
 
 import type { BinaryExpression } from '../../../parser/ast';
 import type { FabGenerator } from '../generator';
 
+/**
+ * Map JavaScript operators to Faber canonical forms.
+ */
+function mapOperatorToFaber(operator: string): string {
+    switch (operator) {
+        case '&&': return 'et';
+        case '||': return 'aut';
+        case '??': return 'vel';
+        default: return operator;
+    }
+}
+
 export function genBinaryExpression(node: BinaryExpression, g: FabGenerator): string {
     const left = g.genExpression(node.left);
     const right = g.genExpression(node.right);
-    return `(${left} ${node.operator} ${right})`;
+    const faberOperator = mapOperatorToFaber(node.operator);
+    return `${left} ${faberOperator} ${right}`;
 }

--- a/fons/faber/codegen/types.ts
+++ b/fons/faber/codegen/types.ts
@@ -317,7 +317,7 @@ export const COMMENT_SYNTAX: Record<CodegenTarget, CommentSyntax> = {
     rs: { line: '//', blockStart: '/*', blockEnd: '*/' },
     cpp: { line: '//', blockStart: '/*', blockEnd: '*/' },
     zig: { line: '//', blockStart: null, blockEnd: null }, // Zig has no block comments
-    fab: { line: '//', blockStart: '/*', blockEnd: '*/' },
+    fab: { line: '#', blockStart: null, blockEnd: null },
 };
 
 /**


### PR DESCRIPTION
## Summary

- Fixed comment syntax from `//` to `#` for fab target
- Added operator mapping for JavaScript operators to Faber canonical forms (`&&` → `et`, `||` → `aut`, `??` → `vel`)  
- Removed unnecessary parentheses around binary expressions
- Enables round-trip compilation (fab → fab → ts) to work correctly

## Test plan

- [x] Verified fab codegen outputs correct comment syntax (`#` instead of `//`)
- [x] Tested logical operators are converted correctly (`&&` → `et`, `||` → `aut`)
- [x] Tested nullish coalescing operator is converted (`??` → `vel`)  
- [x] Verified generated fab files can be parsed back by faber compiler
- [x] Tested round-trip compilation succeeds without parser errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)