### PR TITLE
Fix Rust codegen: Add LegeExpression and @externa function support

### DIFF
--- a/fons/faber/codegen/rs/expressions/lege.ts
+++ b/fons/faber/codegen/rs/expressions/lege.ts
@@ -1,0 +1,31 @@
+/**
+ * Rust Code Generator - Lege Expression (read stdin)
+ *
+ * TRANSFORMS:
+ *   lege        -> { let mut buffer = String::new(); std::io::stdin().read_to_string(&mut buffer).unwrap_or(0); buffer }
+ *   lege lineam -> { let mut line = String::new(); std::io::stdin().read_line(&mut line).unwrap_or(0); line.trim().to_string() }
+ *
+ * TARGET: Rust's std::io::stdin() for reading input as String.
+ *
+ * WHY: Bootstrap compiler needs to read source from stdin.
+ *      Uses inline block expressions to manage mutable buffers.
+ *      Returns empty string on error for consistency with other targets.
+ */
+
+import type { LegeExpression } from '../../../parser/ast';
+import type { RsGenerator } from '../generator';
+
+export function genLegeExpression(node: LegeExpression, g: RsGenerator): string {
+    // Track feature usage for preamble generation
+    g.features.stdin = true;
+
+    if (node.mode === 'line') {
+        // WHY: read_line() appends to buffer including newline, so trim() removes it
+        // Returns usize (bytes read) on success, we ignore and use the string content
+        return '{ let mut line = String::new(); std::io::stdin().read_line(&mut line).unwrap_or(0); line.trim().to_string() }';
+    }
+
+    // Read all of stdin into string buffer
+    // WHY: read_to_string() reads entire input stream until EOF
+    return '{ let mut buffer = String::new(); std::io::stdin().read_to_string(&mut buffer).unwrap_or(0); buffer }';
+}

--- a/fons/faber/codegen/rs/generator.ts
+++ b/fons/faber/codegen/rs/generator.ts
@@ -62,6 +62,7 @@ import { genEstExpression } from './expressions/est';
 import { genPraefixumExpression } from './expressions/praefixum';
 import { genScriptumExpression } from './expressions/scriptum';
 import { genRegexLiteral } from './expressions/regex';
+import { genLegeExpression } from './expressions/lege';
 
 /**
  * Map Latin type names to Rust type names.
@@ -270,6 +271,8 @@ export class RsGenerator {
                 return genScriptumExpression(node, this);
             case 'RegexLiteral':
                 return genRegexLiteral(node, this);
+            case 'LegeExpression':
+                return genLegeExpression(node, this);
             default:
                 throw new Error(`Unknown expression type: ${(node as any).type}`);
         }

--- a/fons/faber/codegen/rs/preamble/index.ts
+++ b/fons/faber/codegen/rs/preamble/index.ts
@@ -19,5 +19,9 @@ export function genPreamble(features: RequiredFeatures): string {
         uses.push('use regex::Regex;');
     }
 
+    if (features.stdin) {
+        uses.push('use std::io::Read;');
+    }
+
     return uses.length > 0 ? uses.join('\n') + '\n' : '';
 }

--- a/fons/faber/codegen/rs/statements/functio.ts
+++ b/fons/faber/codegen/rs/statements/functio.ts
@@ -11,7 +11,7 @@
 
 import type { FunctioDeclaration, BlockStatement } from '../../../parser/ast';
 import type { RsGenerator } from '../generator';
-import { isAsyncFromAnnotations } from '../../types';
+import { isAsyncFromAnnotations, isExternaFromAnnotations } from '../../types';
 
 export function genFunctioDeclaration(node: FunctioDeclaration, g: RsGenerator): string {
     const isAsync = node.async || isAsyncFromAnnotations(node.annotations);
@@ -23,6 +23,11 @@ export function genFunctioDeclaration(node: FunctioDeclaration, g: RsGenerator):
     let returnType = '';
     if (node.returnType) {
         returnType = ` -> ${g.genType(node.returnType)}`;
+    }
+
+    // External function declarations use Rust's extern syntax
+    if (isExternaFromAnnotations(node.annotations)) {
+        return `${g.ind()}extern "C" { fn ${name}${typeParams}(${params})${returnType}; }`;
     }
 
     if (!node.body) {
@@ -46,6 +51,11 @@ export function genMethodDeclaration(node: FunctioDeclaration, g: RsGenerator): 
     let returnType = '';
     if (node.returnType) {
         returnType = ` -> ${g.genType(node.returnType)}`;
+    }
+
+    // External method declarations not supported in impl blocks
+    if (isExternaFromAnnotations(node.annotations)) {
+        throw new Error('External methods (@externa) not supported in Rust impl blocks');
     }
 
     if (!node.body) {

--- a/fons/faber/codegen/rs/statements/varia.ts
+++ b/fons/faber/codegen/rs/statements/varia.ts
@@ -12,8 +12,16 @@
 
 import type { VariaDeclaration } from '../../../parser/ast';
 import type { RsGenerator } from '../generator';
+import { isExternaFromAnnotations } from '../../types';
 
 export function genVariaDeclaration(node: VariaDeclaration, g: RsGenerator): string {
+    // External variable declarations use Rust's extern syntax
+    if (isExternaFromAnnotations(node.annotations)) {
+        const name = node.name.type === 'ArrayPattern' ? '[destructure]' : node.name.name;
+        const typeAnno = node.typeAnnotation ? `: ${g.genType(node.typeAnnotation)}` : '';
+        return `${g.ind()}extern "C" { static ${name}${typeAnno}; }`;
+    }
+
     const isAsync = node.kind === 'figendum' || node.kind === 'variandum';
     const mutKeyword = node.kind === 'varia' || node.kind === 'variandum' ? 'mut ' : '';
 


### PR DESCRIPTION
## Summary
Fixes #84 by implementing the two missing AST node types in the Rust code generator:
- **LegeExpression** for reading standard input
- **@externa function declarations** for external function stubs

## Changes Made

### 1. LegeExpression Support
- ✅ Created `/fons/faber/codegen/rs/expressions/lege.ts` with proper Rust stdin handling
- ✅ Added LegeExpression case to generator switch statement in `generator.ts` 
- ✅ Updated preamble to include `use std::io::Read;` when stdin feature is used
- ✅ Supports both modes:
  - `lege` (all): `{ let mut buffer = String::new(); std::io::stdin().read_to_string(&mut buffer).unwrap_or(0); buffer }`
  - `lege lineam` (line): `{ let mut line = String::new(); std::io::stdin().read_line(&mut line).unwrap_or(0); line.trim().to_string() }`

### 2. @externa Function Support  
- ✅ Added `isExternaFromAnnotations` utility import to function generators
- ✅ Functions with @externa generate `extern "C" { fn name(params) -> type; }` blocks
- ✅ Variables with @externa generate `extern "C" { static name: type; }` blocks
- ✅ Method declarations properly reject @externa (not supported in Rust impl blocks)

## Test Results
- ✅ Previously failing `cli.fab` now compiles successfully
- ✅ Previously failing `semantic/modulus.fab` now compiles successfully  
- ✅ **All 145 files** in `fons/rivus/` now compile to Rust with **0 failures**

## Implementation Notes
- Follows established patterns from TypeScript and Zig codegens
- Uses inline block expressions for mutable buffer management in Rust
- Proper error handling with `.unwrap_or()` fallbacks
- Feature tracking for preamble generation

🎯 **Result**: Rust codegen now successfully compiles 145/145 files (was 143/145)

🤖 Generated with [Claude Code](https://claude.com/claude-code)