### PR TITLE
Fix: Norma stdlib zero-argument functions fail to translate (#89)

### DIFF
--- a/fons/faber/codegen/norma-registry.ts
+++ b/fons/faber/codegen/norma-registry.ts
@@ -169,7 +169,7 @@ export function getNormaReceiverCollectionsForMethod(target: string, method: str
  */
 export function applyNormaModuleCall(target: string, module: string, func: string, args: string[]): string | undefined {
     const translation = getNormaTranslation(target, module, func);
-    if (!translation?.template || !translation?.params) {
+    if (!translation?.template) {
         return undefined;
     }
 


### PR DESCRIPTION
## Summary

Fixed 25 test failures where zero-argument norma stdlib functions (like `fractus()`, `uuid()`, `nunc()`) compiled to bare function calls instead of target-specific implementations.

## Root Cause

`applyNormaModuleCall` at `fons/faber/codegen/norma-registry.ts:172` had incorrect guard:

```typescript
if (!translation?.template || !translation?.params) {
    return undefined;
}
```

This required BOTH `template` AND `params` fields. Zero-argument functions only have `template` in the JSON registry—no `params` field since they take no arguments.

## Changes

Changed line 172 to:

```typescript
if (!translation?.template) {
    return undefined;
}
```

The `params` field is optional and defaults to empty array. The template replacement logic at lines 177-191 already handles this correctly.

## Testing

**Before fix:**
- 65 pass, 25 fail for aleator & tempus modules
- Total test suite: 4770 pass, 56 fail

**After fix:**
- 90 pass, 0 fail for aleator & tempus modules  
- Total test suite: 4795 pass, 31 fail

All 25 zero-arg function failures resolved across all 5 targets (ts, py, cpp, rs, zig).

Fixes #89

🤖 Generated by opifex