### PR TITLE
Fix: Parser tests use obsolete bitwise shift syntax (#90)

### DIFF
--- a/fons/faber/parser/index.test.ts
+++ b/fons/faber/parser/index.test.ts
@@ -758,19 +758,19 @@ describe('parser', () => {
         });
 
         test('left shift', () => {
-            const { program } = parseCode('a << 2');
+            const { program } = parseCode('a sinistratum 2');
             const expr = (program!.body[0] as any).expression;
 
-            expect(expr.type).toBe('BinaryExpression');
-            expect(expr.operator).toBe('<<');
+            expect(expr.type).toBe('ShiftExpression');
+            expect(expr.direction).toBe('sinistratum');
         });
 
         test('right shift', () => {
-            const { program } = parseCode('a >> 2');
+            const { program } = parseCode('a dextratum 2');
             const expr = (program!.body[0] as any).expression;
 
-            expect(expr.type).toBe('BinaryExpression');
-            expect(expr.operator).toBe('>>');
+            expect(expr.type).toBe('ShiftExpression');
+            expect(expr.direction).toBe('dextratum');
         });
 
         test('bitwise precedence: & binds tighter than |', () => {
@@ -782,13 +782,14 @@ describe('parser', () => {
             expect(expr.right.operator).toBe('&');
         });
 
-        test('bitwise precedence: << binds tighter than &', () => {
-            const { program } = parseCode('a & b << 2');
+        test('bitwise precedence: sinistratum binds tighter than &', () => {
+            const { program } = parseCode('a & b sinistratum 2');
             const expr = (program!.body[0] as any).expression;
 
             // Should parse as: a & (b << 2)
             expect(expr.operator).toBe('&');
-            expect(expr.right.operator).toBe('<<');
+            expect(expr.right.type).toBe('ShiftExpression');
+            expect(expr.right.direction).toBe('sinistratum');
         });
 
         test('bitwise precedence: bitwise binds tighter than comparison', () => {


### PR DESCRIPTION
## Summary
Fixed 3 parser tests that were using the obsolete `<<` and `>>` operators, which were intentionally removed from the language to avoid ambiguity with nested generics.

## Changes
Updated the following tests to use the correct `dextratum` (right shift) and `sinistratum` (left shift) keyword syntax:

- **left shift test**: `a << 2` → `a sinistratum 2`
- **right shift test**: `a >> 2` → `a dextratum 2`  
- **precedence test**: `a & b << 2` → `a & b sinistratum 2`

Also updated assertions to expect `ShiftExpression` nodes with a `direction` property instead of `BinaryExpression` nodes with an `operator` property.

## Testing
✅ All 3 previously failing tests now pass
✅ Full parser test suite passes (430 tests)

Fixes #90

🤖 Generated by opifex