### PR TITLE
Fix: Zig codegen external function declarations (@ externa) (#83)

### DIFF
--- a/fons/faber/codegen/zig/statements/genus.ts
+++ b/fons/faber/codegen/zig/statements/genus.ts
@@ -18,6 +18,7 @@
 
 import type { GenusDeclaration, FieldDeclaration, FunctioDeclaration } from '../../../parser/ast';
 import type { ZigGenerator } from '../generator';
+import { isExternaFromAnnotations } from '../../types';
 
 /** Collection type names that require allocators */
 const COLLECTION_TYPES = ['lista', 'tabula', 'copia'];
@@ -168,6 +169,11 @@ function genStructInit(node: GenusDeclaration, g: ZigGenerator, needsAlloc: bool
  *   -> fn creo(self: *Self) void { if (self.aetas < 0) { self.aetas = 0; } }
  */
 function genCreoMethod(node: FunctioDeclaration, g: ZigGenerator, needsAlloc: boolean): string {
+    // EDGE: External declarations are not allowed as constructors (creo must have a body)
+    if (isExternaFromAnnotations(node.annotations)) {
+        throw new Error('External declarations (@ externa) not supported for constructors');
+    }
+
     // EDGE: Abstract methods have no body - Zig doesn't support abstract methods
     if (!node.body) {
         throw new Error('Abstract methods not supported for Zig target');
@@ -209,6 +215,11 @@ function genCreoMethod(node: FunctioDeclaration, g: ZigGenerator, needsAlloc: bo
  * EDGE: anytype is not valid as a return type in Zig.
  */
 function genStructMethod(node: FunctioDeclaration, g: ZigGenerator, needsAlloc: boolean): string {
+    // EDGE: External declarations are not allowed as methods (methods must have a body)
+    if (isExternaFromAnnotations(node.annotations)) {
+        throw new Error('External declarations (@ externa) not supported for methods');
+    }
+
     // EDGE: Abstract methods have no body - Zig doesn't support abstract methods
     if (!node.body) {
         throw new Error('Abstract methods not supported for Zig target');

--- a/fons/rivus/semantic/errores.fab
+++ b/fons/rivus/semantic/errores.fab
@@ -23,6 +23,7 @@ ordo SemanticErrorCodice {
     ModuleNotFound          # S012: Cannot find module
     CircularImport          # S013: Circular import detected
     ModuleParseError        # S014: Failed to parse module
+    MissingFunctionBody     # S016: Function has no body (not @ externa)
 }
 
 # ============================================================================
@@ -163,6 +164,15 @@ functio moduleParseError(textus path) -> SemanticErrorNuntius {
     redde {
         textus: scriptum("Failed to parse module '§'", path),
         auxilium: "Fix the syntax errors in the imported module before importing it."
+    } qua SemanticErrorNuntius
+}
+
+# Missing function body error
+@ publica
+functio missingFunctionBodyError(textus nomen) -> SemanticErrorNuntius {
+    redde {
+        textus: scriptum("Function '§' has no body", nomen),
+        auxilium: "Regular functions require a body. Use '@ externa' annotation for external declarations."
     } qua SemanticErrorNuntius
 }
 

--- a/fons/rivus/semantic/sententia/declara.fab
+++ b/fons/rivus/semantic/sententia/declara.fab
@@ -9,7 +9,7 @@ ex "../typi" importa functioTypus, usitatumTypus, genusTypus, pactumTypus, ordoT
 ex "../typi" importa formaTypum, assignabileAd
 ex "../scopus" importa Symbolum, SymbolumSpecies, ScopusSpecies, quaereSymbolumLocale
 ex "../nucleus" importa estGenericusTypus
-ex "../errores" importa noTypeOrInitializerError, typeMismatchError, awaitOutsideAsyncError
+ex "../errores" importa noTypeOrInitializerError, typeMismatchError, awaitOutsideAsyncError, missingFunctionBodyError
 ex "../../ast/sententia" importa Sententia, VariaGenus
 ex "../../ast/typus" importa TypusAnnotatio, TypusParametrum
 
@@ -167,6 +167,12 @@ functio analyzeFunctioDeclaratio(Resolvitor r, Sententia functioStmt) -> vacuum 
                     mutabilis: falsum,
                     locus: f.locus
                 } qua Symbolum)
+            }
+
+            # Check for missing body (functions must have body unless @ externa or abstract)
+            si nihil f.corpus et non f.externa et non f.abstracta {
+                fixum err = missingFunctionBodyError(f.nomen)
+                a.error(err.textus, f.locus)
             }
 
             # Analyze body in new scope


### PR DESCRIPTION
## Summary

Fixes #83 by adding support for `@ externa` function declarations in Zig codegen. External functions now emit `extern fn` declarations instead of throwing "Abstract methods not supported" errors.

## Changes

### Zig Codegen (faber)
- **functio.ts**: Check for `@ externa` annotation before the "no body" guard. External functions emit `extern fn` syntax.
- **genus.ts**: Add explicit checks to reject `@ externa` in constructors and methods (these must have bodies).

### Rivus Semantic Analyzer
- **errores.fab**: Add `MissingFunctionBody` error code (S016) with helpful message.
- **sententia/declara.fab**: Validate that functions without bodies must have `@ externa` or be abstract.

## Testing

### Before
```bash
bun run build:rivus -t zig
# semantic/modulus.fab: Abstract methods not supported for Zig target
```

### After
```bash
bun run build:rivus -t zig
# Compiled 145/145 files to opus/rivus/fons/zig/ (zig, 3340ms)
```

### Example Output
```zig
extern fn _readFileSync(via: []const u8) []const u8;
extern fn _existsSync(via: []const u8) bool;
extern fn _dirname(via: []const u8) []const u8;
extern fn _resolve(basis: []const u8, relativum: []const u8) []const u8;
```

## Affected Files
- `fons/rivus/semantic/modulus.fab` - now compiles to Zig successfully
- `fons/norma/solum.fab` - 20+ @ externa declarations now supported

🤖 Generated by opifex