### PR TITLE
Integrate target capability validation into codegen pipeline (#104)

### DIFF
--- a/fons/faber/codegen/index.ts
+++ b/fons/faber/codegen/index.ts
@@ -41,6 +41,7 @@ import { generatePy } from './py/index';
 import { generateRs } from './rs/index';
 import { generateCpp } from './cpp/index';
 import { generateFab } from './fab/index';
+import { validateTargetCompatibility, TargetCompatibilityError } from './validator';
 
 // =============================================================================
 // PUBLIC API
@@ -79,6 +80,12 @@ export { generateFab } from './fab/index';
 export function generate(program: Program, options: CodegenOptions = {}): string {
     // WHY: Default to TypeScript for web-first development
     const target = options.target ?? 'ts';
+
+    // Validate target compatibility BEFORE codegen
+    const validationErrors = validateTargetCompatibility(program, target);
+    if (validationErrors.length > 0) {
+        throw new TargetCompatibilityError(validationErrors, target);
+    }
 
     switch (target) {
         case 'ts':

--- a/fons/proba/capabilities/integration.test.ts
+++ b/fons/proba/capabilities/integration.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Integration Tests - Target capability validation in compilation pipeline
+ *
+ * Tests that validation errors are thrown during compilation when using
+ * unsupported features for specific targets.
+ */
+
+import { generate } from '../../faber/codegen';
+import { parse } from '../../faber/parser';
+import { tokenize } from '../../faber/tokenizer';
+import { TargetCompatibilityError } from '../../faber/codegen/validator';
+import { describe, test, expect } from 'bun:test';
+
+/**
+ * Helper to compile Faber source.
+ * WHY: Encapsulates the three-phase pipeline for cleaner test code.
+ */
+function compile(source: string, target: string): string {
+    const { tokens } = tokenize(source);
+    const { program } = parse(tokens);
+    return generate(program!, { target });
+}
+
+describe('codegen integration', () => {
+    test('async function compiles to TypeScript', () => {
+        const source = 'functio f() fiet numerus { redde 1 }';
+        expect(() => compile(source, 'ts')).not.toThrow();
+    });
+
+    test('async function fails for Zig', () => {
+        const source = 'functio f() fiet numerus { redde 1 }';
+        expect(() => compile(source, 'zig')).toThrow(TargetCompatibilityError);
+    });
+
+    test('generator function compiles to TypeScript', () => {
+        const source = 'functio f() fiunt numerus { cede 1 cede 2 }';
+        expect(() => compile(source, 'ts')).not.toThrow();
+    });
+
+    test('generator function fails for Rust', () => {
+        const source = 'functio f() fiunt numerus { cede 1 cede 2 }';
+        expect(() => compile(source, 'rs')).toThrow(TargetCompatibilityError);
+    });
+
+    test('compatible code compiles to all targets', () => {
+        // Simple function with no advanced features
+        const source = 'functio add(numerus a, numerus b) fit numerus { redde a + b }';
+        for (const target of ['ts', 'py', 'rs', 'zig', 'cpp']) {
+            expect(() => compile(source, target)).not.toThrow();
+        }
+    });
+});


### PR DESCRIPTION
## Summary

- Wire capability validation into compilation pipeline before codegen
- Invalid programs now fail with clear error messages before code generation
- CLI formats compatibility errors with file:line:col and actionable hints

## Changes

- `fons/faber/codegen/index.ts`: Call `validateTargetCompatibility()` before dispatching to target generators
- `fons/faber/cli.ts`: Add `TargetCompatibilityError` handler matching CLI error format
- `fons/proba/capabilities/integration.test.ts`: End-to-end tests for validation integration

## Testing

- All 33 capability tests pass (28 baseline + 5 new integration tests)
- All 49 codegen unit tests pass
- Manual CLI verification:
  - `echo 'functio f() fiet numerus { redde 1 }' | bun run faber compile -t zig` → clear error with hint
  - `echo 'functio add(numerus a, numerus b) fit numerus { redde a + b }' | bun run faber compile -t zig` → compiles successfully

## Example Output

```
Target compatibility errors:
  example.fab:1:1 - Target 'zig' does not support async functions (futura)
    hint: Refactor to synchronous code; consider explicit callbacks or event loop
```

Closes #104

🤖 Generated by opifex