### PR TITLE
Fix rivus discerne typing across modules

### DIFF
--- a/fons/rivus/semantic/index.fab
+++ b/fons/rivus/semantic/index.fab
@@ -9,9 +9,11 @@ ex "./scopus" importa Symbolum, SymbolumSpecies
 ex "./modulus" importa estLocaleImportum, estNormaImportum, resolveModulum, ModulusExportum
 ex "./expressia/index" importa resolveExpressia
 ex "./sententia/index" importa analyzeSententia
+ex "./sententia/declara" importa resolveTypusAnnotatio
 ex "../ast/radix" importa Programma
 ex "../ast/expressia" importa Expressia
 ex "../ast/sententia" importa Sententia, MorphologiaDeclaratio
+ex "../ast/typus" importa TypusAnnotatio
 ex "../parser/morphologia" importa parseMethodum
 
 # ============================================================================
@@ -92,9 +94,12 @@ functio predeclare(Resolvitor r, Sententia stmt) -> vacuum {
             ex f.parametra pro param {
                 paramTypi.adde(IGNOTUM)
             }
-            # WHY: Use IGNOTUM when return type is declared, matching faber behavior.
-            # This allows forward function calls to pass type checks during body analysis.
-            fixum reditusTypus = nonnihil f.typusReditus sic IGNOTUM secus VACUUM
+            # WHY: Preserve declared return types so callers can infer receiver types
+            # from forward function calls (critical for norma method translation).
+            varia reditusTypus = VACUUM
+            si nonnihil f.typusReditus {
+                reditusTypus = resolveTypusAnnotatio(r, f.typusReditus qua TypusAnnotatio)
+            }
             fixum fnTypus = functioTypus(paramTypi, reditusTypus, f.asynca, falsum)
 
             a.definie({
@@ -244,6 +249,29 @@ functio predeclare(Resolvitor r, Sententia stmt) -> vacuum {
                                         mutabilis: falsum,
                                         locus: spec.locus
                                     } qua Symbolum)
+
+                                    # WHY: If a discretio type is imported by name, also import its
+                                    # variant types as `LocalName.VariansNomen` so `discerne` can
+                                    # resolve bindings and enable norma translations.
+                                    fixum prefix = spec.importatum + "."
+                                    de modulus.exporta pro nomen {
+                                        si nomen.startsWith(prefix) {
+                                            fixum exportum = modulus.exporta[nomen] qua ModulusExportum
+                                            fixum suffix = nomen.slice(prefix.length)
+                                            fixum qualNomen = scriptum("§.§", spec.locale, suffix)
+
+                                            # Avoid duplicate definitions if multiple imports overlap.
+                                            si nihil a.scopus.symbola[qualNomen] {
+                                                a.definie({
+                                                    nomen: qualNomen,
+                                                    semanticTypus: exportum.typus,
+                                                    species: exportum.species,
+                                                    mutabilis: falsum,
+                                                    locus: exportum.locus
+                                                } qua Symbolum)
+                                            }
+                                        }
+                                    }
                                 } secus {
                                     a.error(scriptum("'§' is not exported from '§'", spec.importatum, imp.fons), spec.locus)
                                 }

--- a/fons/rivus/semantic/modulus.fab
+++ b/fons/rivus/semantic/modulus.fab
@@ -9,7 +9,7 @@
 # - "norma" and "norma/*" are handled as compiler intrinsics (not files)
 # - Other paths pass through to target language (external packages)
 
-ex "./typi" importa SemanticTypus, IGNOTUM, VACUUM, functioTypus, usitatumTypus
+ex "./typi" importa SemanticTypus, IGNOTUM, VACUUM, functioTypus, usitatumTypus, pactumTypus
 ex "./typi" importa genusTypus, genericumTypus, primitivumTypus
 ex "./scopus" importa SymbolumSpecies
 ex "../ast/positio" importa Locus
@@ -190,10 +190,31 @@ functio extraheExporta(Programma programma, textus via) -> ModulusResolutum {
                 } qua ModulusExportum
             }
             casu PactumDeclaratio ut p {
+                # WHY: Preserve method return types so callers can infer types from calls
+                # (needed for norma translation when compiling in dependency order).
+                varia methodi = {} innatum tabula<textus, SemanticTypus>
+                ex p.methodi pro methodSignum {
+                    varia paramTypi = [] innatum lista<SemanticTypus>
+                    ex methodSignum.parametra pro param {
+                        si nonnihil param.typus {
+                            paramTypi.adde(resolveTypusShallow(param.typus qua TypusAnnotatio))
+                        } secus {
+                            paramTypi.adde(IGNOTUM)
+                        }
+                    }
+
+                    varia reditusTypus = VACUUM qua SemanticTypus
+                    si nonnihil methodSignum.typusReditus {
+                        reditusTypus = resolveTypusShallow(methodSignum.typusReditus qua TypusAnnotatio)
+                    }
+
+                    methodi[methodSignum.nomen] = functioTypus(paramTypi, reditusTypus, methodSignum.asynca, falsum)
+                }
+
                 exporta[p.nomen] = {
                     nomen: p.nomen,
                     species: SymbolumSpecies.Pactum,
-                    typus: usitatumTypus(p.nomen, falsum),
+                    typus: pactumTypus(p.nomen, methodi, falsum),
                     locus: p.locus
                 } qua ModulusExportum
             }
@@ -212,6 +233,32 @@ functio extraheExporta(Programma programma, textus via) -> ModulusResolutum {
                     typus: usitatumTypus(d.nomen, falsum),
                     locus: d.locus
                 } qua ModulusExportum
+
+                # WHY: Pattern matching (`discerne`) expects variant types to be resolvable as
+                # `DiscretioNomen.VariansNomen`, even across module boundaries.
+                ex d.variantes pro variante {
+                    varia campi = {} innatum tabula<textus, SemanticTypus>
+                    ex variante.campi pro campo {
+                        campi[campo.nomen] = resolveTypusShallow(campo.typus)
+                    }
+
+                    fixum variantTypus = genusTypus(
+                        variante.nomen,
+                        campi,
+                        {} innatum tabula<textus, SemanticTypus>,
+                        {} innatum tabula<textus, SemanticTypus>,
+                        {} innatum tabula<textus, SemanticTypus>,
+                        falsum
+                    )
+
+                    fixum qualNomen = scriptum("§.§", d.nomen, variante.nomen)
+                    exporta[qualNomen] = {
+                        nomen: qualNomen,
+                        species: SymbolumSpecies.Genus,
+                        typus: variantTypus,
+                        locus: variante.locus
+                    } qua ModulusExportum
+                }
             }
             casu TypusAliasDeclaratio ut t {
                 exporta[t.nomen] = {

--- a/fons/rivus/semantic/sententia/imperium.fab
+++ b/fons/rivus/semantic/sententia/imperium.fab
@@ -4,7 +4,7 @@
 
 ex "../resolvitor" importa Resolvitor
 ex "../typi" importa SemanticTypus, IGNOTUM
-ex "../scopus" importa ScopusSpecies, SymbolumSpecies
+ex "../scopus" importa ScopusSpecies, Symbolum, SymbolumSpecies, quaereSymbolum
 ex "../../ast/sententia" importa Sententia
 
 # =============================================================================
@@ -211,8 +211,9 @@ functio analyzeDiscerne(Resolvitor r, Sententia discerneStmt) -> vacuum {
                         casu Usitatum ut u {
                             # For discriminated union, lookup Discriminant.Variant
                             fixum qualNomen = scriptum("§.§", u.nomen, pattern.variansNomen)
-                            si nonnihil a.scopus.symbola[qualNomen] {
-                                variantTypus = a.scopus.symbola[qualNomen].semanticTypus
+                            fixum symbolum = quaereSymbolum(a.scopus, qualNomen)
+                            si nonnihil symbolum {
+                                variantTypus = (symbolum qua Symbolum).semanticTypus
                             }
                         }
                         casu _ {


### PR DESCRIPTION
## Summary
- Fixes rivus self-hosting (`build:artifex`) by keeping `discerne` case bindings typed across module boundaries, so norma method translations (e.g. `.longitudo()` -> `.length`) apply reliably.
- Exports discretio variant symbols and pactum method signatures from module resolution, and aliases variant symbols for named imports.
- Updates `build:rivus` to inject required extern fs/path implementations and rebuild `opus/bin/rivus` so `build:artifex` uses the updated compiler.

## Verification
- `bun run build:rivus`
- `bun run build:artifex`