### PR TITLE
Improve visual rhythm by adding blank lines between related functions

### DIFF
--- a/fons/faber/semantic/modules.ts
+++ b/fons/faber/semantic/modules.ts
@@ -345,6 +345,7 @@ function extractFunctioExport(stmt: FunctioDeclaration, ctx: ModuleTypeContext):
     };
 }
 
+
 /**
  * Extract export from genus (class) declaration.
  */
@@ -366,6 +367,7 @@ function extractGenusExport(stmt: GenusDeclaration, ctx: ModuleTypeContext): Mod
         kind: 'genus',
     };
 }
+
 
 /**
  * Extract export from pactum (interface) declaration.
@@ -390,6 +392,7 @@ function extractPactumExport(stmt: PactumDeclaration, ctx: ModuleTypeContext): M
     };
 }
 
+
 /**
  * Extract export from ordo (enum) declaration.
  */
@@ -400,6 +403,7 @@ function extractOrdoExport(stmt: OrdoDeclaration): ModuleExport {
         kind: 'ordo',
     };
 }
+
 
 /**
  * Extract export from discretio (tagged union) declaration.
@@ -426,6 +430,7 @@ function extractDiscretioExport(stmt: DiscretioDeclaration): ModuleExport {
     };
 }
 
+
 /**
  * Extract export from typus (type alias) declaration.
  */
@@ -436,6 +441,7 @@ function extractTypusExport(stmt: TypeAliasDeclaration): ModuleExport {
         kind: 'type',
     };
 }
+
 
 /**
  * Extract export from variable declaration.

--- a/fons/faber/semantic/scope.ts
+++ b/fons/faber/semantic/scope.ts
@@ -76,6 +76,7 @@ export function createGlobalScope(): Scope {
     };
 }
 
+
 /**
  * Create a child scope.
  */
@@ -86,6 +87,7 @@ export function createScope(parent: Scope, kind: Scope['kind'] = 'block'): Scope
         kind,
     };
 }
+
 
 /**
  * Define a symbol in the current scope.
@@ -103,6 +105,7 @@ export function defineSymbol(scope: Scope, symbol: Symbol): string | null {
 
     return null;
 }
+
 
 /**
  * Look up a symbol by name, walking up the scope chain.
@@ -123,6 +126,7 @@ export function lookupSymbol(scope: Scope, name: string): Symbol | null {
     return null;
 }
 
+
 /**
  * Look up a symbol only in the current scope (no parent traversal).
  *
@@ -131,6 +135,7 @@ export function lookupSymbol(scope: Scope, name: string): Symbol | null {
 export function lookupSymbolLocal(scope: Scope, name: string): Symbol | null {
     return scope.symbols.get(name) ?? null;
 }
+
 
 /**
  * Update an existing symbol's type in the current scope.
@@ -151,6 +156,7 @@ export function updateSymbolType(scope: Scope, name: string, type: SemanticType)
 
     return false;
 }
+
 
 /**
  * Find the enclosing function scope.

--- a/fons/faber/semantic/types.ts
+++ b/fons/faber/semantic/types.ts
@@ -209,12 +209,14 @@ export function primitiveType(name: PrimitiveType['name'], nullable?: boolean): 
     return { kind: 'primitive', name, nullable };
 }
 
+
 /**
  * Create a generic type.
  */
 export function genericType(name: string, typeParameters: SemanticType[], nullable?: boolean): GenericType {
     return { kind: 'generic', name, typeParameters, nullable };
 }
+
 
 /**
  * Create a function type.
@@ -223,12 +225,14 @@ export function functionType(parameterTypes: SemanticType[], returnType: Semanti
     return { kind: 'function', parameterTypes, returnType, async, hasCuratorParam };
 }
 
+
 /**
  * Create a union type.
  */
 export function unionType(types: SemanticType[]): UnionType {
     return { kind: 'union', types };
 }
+
 
 /**
  * Create an unknown type.
@@ -237,6 +241,7 @@ export function unknownType(reason?: string): UnknownType {
     return { kind: 'unknown', reason };
 }
 
+
 /**
  * Create a user-defined type.
  */
@@ -244,12 +249,14 @@ export function userType(name: string, nullable?: boolean): UserType {
     return { kind: 'user', name, nullable };
 }
 
+
 /**
  * Create an enum type.
  */
 export function enumType(name: string, members: Map<string, SemanticType>, nullable?: boolean): EnumType {
     return { kind: 'enum', name, members, nullable };
 }
+
 
 /**
  * Create a genus (class/struct) type.
@@ -265,6 +272,7 @@ export function genusType(
     return { kind: 'genus', name, fields, methods, staticFields, staticMethods, nullable };
 }
 
+
 /**
  * Create a pactum (interface) type.
  */
@@ -272,12 +280,14 @@ export function pactumType(name: string, methods: Map<string, FunctionType>, nul
     return { kind: 'pactum', name, methods, nullable };
 }
 
+
 /**
  * Create a discretio (tagged union) type.
  */
 export function discretioType(name: string, variants: Map<string, VariantInfo>, nullable?: boolean): DiscretioType {
     return { kind: 'discretio', name, variants, nullable };
 }
+
 
 /**
  * Create a namespace type.


### PR DESCRIPTION
## Summary
- Add extra blank line spacing between consecutive helper functions in semantic analysis modules
- Improves code readability and visual rhythm per compiler-rules.md guidelines
- Affects: `semantic/modules.ts`, `semantic/types.ts`, `semantic/scope.ts`

Closes #132

---
🤖 Generated by agent run `2b49f8aa` (claude-sonnet-4-5)