### PR TITLE
rivus semantic: allow cede in incipiet

### DIFF
--- a/fons/rivus/semantic/sententia/index.fab
+++ b/fons/rivus/semantic/sententia/index.fab
@@ -139,7 +139,18 @@ functio analyzeSententia(Resolvitor r, Sententia stmt) -> vacuum {
             # WHY: Recursively analyze the incipiet body so method calls get
             # their morphologia resolved for norma translation.
             si nonnihil i.corpus {
+                # WHY: incipiet is async, so cede should be allowed in body
+                fixum a = r.analyzator()
+                fixum prevAsync = a.currentFunctioAsync
+                fixum prevGenerator = a.currentFunctioGenerator
+
+                a.currentFunctioAsync = verum
+                a.currentFunctioGenerator = falsum
+
                 r.sententia(i.corpus)
+
+                a.currentFunctioAsync = prevAsync
+                a.currentFunctioGenerator = prevGenerator
             }
         }
 


### PR DESCRIPTION
## Summary
Treat `incipiet { ... }` as an async context during Rivus semantic analysis so `cede` is allowed inside.

## Why
`fons/exempla/incipiet/incipiet.fab` uses `cede` inside `incipiet`, but semantic analysis previously required an async/generator function context.

## Notes
This does not make Go support async (`futura`)—that remains a target capability check.