### PR TITLE
rivus: do not default genus methods to public

### DIFF
--- a/fons/rivus/parser/sententia/declara.fab
+++ b/fons/rivus/parser/sententia/declara.fab
@@ -288,9 +288,6 @@ functio parseGenusDeclaratio(Resolvitor r, bivalens abstractum) -> Sententia {
 
         # Check if this is a method or field
         si p.probaVerbum("functio") {
-            si non visibilitasExplicita {
-                visibilitas = Visibilitas.Publica
-            }
             # WHY: Methods use full functio syntax but remain inside genus.
             p.procede()
             fixum methodLocus = p.locusActualis()


### PR DESCRIPTION
## Summary
Stops defaulting `genus` methods to `publicus` visibility when no explicit visibility is provided.

## Why
Go method export semantics depend on capitalization. When Rivus defaulted genus methods to `Publica`, Go codegen would capitalize methods (exported) while call sites remained lowercase, breaking `genus/methodi` exempla.

## Change
- `fons/rivus/parser/sententia/declara.fab`: remove the implicit `visibilitas = Visibilitas.Publica` assignment for genus methods when no explicit visibility is present.

## Notes
This keeps method naming consistent with the source unless `publicus` is explicitly requested.