### PR TITLE
Add vel coalesce operator for Go codegen (#179)

### DIFF
--- a/fons/rivus/codegen/go/expressia/index.fab
+++ b/fons/rivus/codegen/go/expressia/index.fab
@@ -44,6 +44,12 @@ functio genExpressia(Expressia expr, GoGenerator g) -> textus {
             elige signum {
                 casu "et" { signum = "&&" }
                 casu "aut" { signum = "||" }
+                casu "vel" {
+                    # WHY: Go lacks nullish coalescing operator. Generate inline func that
+                    # returns left value when non-nil, otherwise returns right fallback.
+                    # Optional chaining yields interface{}, so check via != nil.
+                    redde scriptum("func() interface{} { if _left := §; _left != nil { return _left }; return § }()", sinister, dexter)
+                }
             }
 
             redde scriptum("(§ § §)", sinister, signum, dexter)


### PR DESCRIPTION
## Summary
- Implements `vel` coalesce operator for Go target in rivus
- Generates inline function that checks left operand for nil before returning fallback
- Closes #179

## Implementation
Added handling for `vel` in `BinariaExpressia` codegen (fons/rivus/codegen/go/expressia/index.fab:47-52):
- Maps `A vel B` to: `func() interface{} { if _left := A; _left != nil { return _left }; return B }()`
- Works with optional chaining from #178

## Test plan
- [x] Rebuild compiler: `bun run build`
- [x] Regenerate exempla: `bun run build:exempla -c rivus -t go -f optionalis`
- [x] Verify generated Go compiles: `go build optionalis.go`
- [x] Confirm `bob?.address?.city vel "Unknown"` generates valid Go code

🤖 Generated with [Claude Code](https://claude.com/claude-code)