### PR TITLE
refactor: tighten rivus AST unions

### DIFF
--- a/fons/rivus/ast/expressia.fab
+++ b/fons/rivus/ast/expressia.fab
@@ -10,6 +10,18 @@ ex "./typus" importa TypusAnnotatio
 # SUPPORTING TYPES
 # ============================================================================
 
+@ publicum
+# Lambda body: either an expression or a block
+# WHY: Lambdas can be `pro x: expr` or `pro x { ... }`.
+discretio LambdaCorpus {
+    Expressia {
+        Expressia valor
+    }
+    Massa {
+        MassaSententia valor
+    }
+}
+
 # Literal value type - what kind of constant this is
 @ publicum
 ordo LitteraGenus {
@@ -71,6 +83,9 @@ genus MorphologiaInvocatio {
 # ============================================================================
 # EXPRESSIA DISCRETIO
 # ============================================================================
+
+# OPTIONAL TYPES
+# WHY: ignotum is reserved for pending union definitions (replace with unions).
 
 # All expression types as a tagged union
 #
@@ -219,8 +234,9 @@ discretio Expressia {
     # Example: praefixum { ... }
     PraefixumExpressia {
         Locus locus
-        ignotum corpus
+        LambdaCorpus corpus
     }
+
 
     # -------------------------------------------------------------------------
     # Calls and Member Access
@@ -323,7 +339,7 @@ discretio Expressia {
     LambdaExpressia {
         Locus locus
         lista<LambdaParametrum> parametra
-        ignotum corpus           # expression body or MassaSententia
+        LambdaCorpus corpus
         TypusAnnotatio? typusReditus    # optional return type
     }
 

--- a/fons/rivus/ast/sententia.fab
+++ b/fons/rivus/ast/sententia.fab
@@ -269,6 +269,11 @@ genus AdVinculum {
 # SENTENTIA DISCRETIO
 # ============================================================================
 
+# OPTIONAL FIELDS
+# - Semantically optional: valid syntax can omit the value (e.g., redde, default casus).
+# - Structurally optional: only present for some grammatical forms (e.g., incipit ergo).
+# WHY: We encode both with `?`; each field documents which case applies.
+
 # All statement types as a tagged union
 #
 # Each variant contains its fields directly. Use `finge` to construct:
@@ -297,8 +302,8 @@ discretio Sententia {
         Locus locus
         VariaGenus species
         textus nomen
-        TypusAnnotatio? typus
-        Expressia? valor
+        TypusAnnotatio? typus      # WHY: optional type annotation
+        Expressia? valor           # WHY: optional initializer
         bivalens externa        # @ externa annotation
         Visibilitas? visibilitas  # @ publica annotation for module-level export
     }
@@ -310,7 +315,7 @@ discretio Sententia {
         textus fons              # source path/module
         lista<ImportaSpecificator> specificatores
         bivalens totum           # true for wildcard *
-        textus? totumAlias       # alias for * ut name
+        textus? totumAlias       # WHY: optional alias for * ut name
     }
 
     # Destructure declaration
@@ -342,10 +347,10 @@ discretio Sententia {
     FunctioDeclaratio {
         Locus locus
         textus nomen
-        lista<TypusParametrum>? generaParametra
+        lista<TypusParametrum>? generaParametra # WHY: optional generics
         lista<Parametrum> parametra
-        TypusAnnotatio? typusReditus
-        Sententia? corpus        # MassaSententia
+        TypusAnnotatio? typusReditus            # WHY: optional return type annotation
+        MassaSententia? corpus   # WHY: optional for @ externa declarations
         bivalens asynca
         bivalens generator
         bivalens abstracta
@@ -353,8 +358,8 @@ discretio Sententia {
         bivalens externa        # @ externa annotation
         Visibilitas? visibilitas
         ReddeVerbum? reddeVerbum
-        MorphologiaDeclaratio? morphologia
-        lista<FunctioModificator>? modificatores
+        MorphologiaDeclaratio? morphologia      # WHY: optional method morphology
+        lista<FunctioModificator>? modificatores # WHY: optional modifiers list
     }
 
     # -------------------------------------------------------------------------
@@ -366,14 +371,14 @@ discretio Sententia {
     GenusDeclaratio {
         Locus locus
         textus nomen
-        lista<textus>? generaParametra
-        textus? extendit         # sub Parent
-        lista<textus>? implet    # implet Interface
+        lista<textus>? generaParametra # WHY: optional generics
+        textus? extendit         # WHY: optional sub Parent
+        lista<textus>? implet    # WHY: optional implet Interface list
         bivalens abstractum
         lista<CampusDeclaratio> campi
-        Sententia? structor      # FunctioDeclaratio (WHY: "constructor" is JS reserved)
-        lista<Sententia> methodi # lista<FunctioDeclaratio>
-        MorphologiaDeclaratio? morphologia
+        FunctioDeclaratio? structor   # WHY: optional constructor
+        lista<FunctioDeclaratio> methodi
+        MorphologiaDeclaratio? morphologia      # WHY: optional genus morphology
         Visibilitas? visibilitas  # @ publica annotation for module-level export
     }
 
@@ -382,7 +387,7 @@ discretio Sententia {
     PactumDeclaratio {
         Locus locus
         textus nomen
-        lista<textus>? generaParametra
+        lista<textus>? generaParametra # WHY: optional generics
         lista<PactumMethodus> methodi
         Visibilitas? visibilitas  # @ publica annotation for module-level export
     }
@@ -393,7 +398,7 @@ discretio Sententia {
         Locus locus
         textus nomen
         TypusAnnotatio typus
-        textus? scopusNomen      # for typeof: typus X = typus y
+        textus? scopusNomen      # WHY: optional typeof scope
         Visibilitas? visibilitas  # @ publica annotation for module-level export
     }
 
@@ -411,7 +416,7 @@ discretio Sententia {
     DiscretioDeclaratio {
         Locus locus
         textus nomen
-        lista<textus>? generaParametra
+        lista<textus>? generaParametra # WHY: optional generics
         lista<VariansDeclaratio> variantes
         Visibilitas? visibilitas  # @ publica annotation for module-level export
     }
@@ -465,7 +470,7 @@ discretio Sententia {
         Locus locus
         Expressia discriminans
         lista<EligeCasus> casus
-        Sententia? praedefinitum # MassaSententia (secus default)
+        MassaSententia? praedefinitum # WHY: optional default casus
         CapeClausula? cape
     }
 
@@ -496,7 +501,7 @@ discretio Sententia {
         Locus locus
         Sententia corpus         # MassaSententia
         CapeClausula? cape
-        Sententia? demum         # MassaSententia (finally)
+        MassaSententia? demum    # WHY: optional finally block
     }
 
     # Throw statement
@@ -513,7 +518,7 @@ discretio Sententia {
         Locus locus
         Sententia corpus         # MassaSententia
         CapeClausula? cape
-        Expressia? condicio      # for do-while: fac { } dum cond
+        Expressia? condicio      # WHY: optional do-while condition
     }
 
     # Assert statement
@@ -521,7 +526,7 @@ discretio Sententia {
     AdfirmaSententia {
         Locus locus
         Expressia condicio
-        Expressia? nuntius       # optional message
+        Expressia? nuntius       # WHY: optional message
     }
 
     # -------------------------------------------------------------------------
@@ -540,7 +545,7 @@ discretio Sententia {
     # Example: redde 42, redde
     ReddeSententia {
         Locus locus
-        Expressia? valor
+        Expressia? valor         # WHY: optional redde value
     }
 
     # Break statement
@@ -565,24 +570,24 @@ discretio Sententia {
     # Example: incipit { scribe "Hello" }
     IncipitSententia {
         Locus locus
-        Sententia? corpus        # MassaSententia
-        Sententia? ergo          # incipit ergo ...
+        MassaSententia? corpus   # WHY: optional incipit body
+        Sententia? ergo          # WHY: optional incipit ergo clause
     }
 
     # Entry point (async)
     # Example: incipiet { cede fetch() }
     IncipietSententia {
         Locus locus
-        Sententia? corpus        # MassaSententia
-        Sententia? ergo
+        MassaSententia? corpus   # WHY: optional incipiet body
+        Sententia? ergo          # WHY: optional incipiet ergo clause
     }
 
     # Resource management statement
     # Example: cura arena fit mem { ... }
     CuraSententia {
         Locus locus
-        CuratorGenus? curatorSpecies
-        Expressia? res           # resource expression
+        CuratorGenus? curatorSpecies # WHY: optional when `res` provides curator
+        Expressia? res           # WHY: optional for bare curator form
         textus vinculum          # binding name
         TypusAnnotatio? typus
         bivalens asynca
@@ -597,7 +602,7 @@ discretio Sententia {
         textus scopus            # target string
         lista<Expressia> argumenta
         AdVinculum? vinculum
-        Sententia? corpus        # MassaSententia
+        MassaSententia? corpus   # WHY: optional handler body
         CapeClausula? cape
     }
 

--- a/fons/rivus/codegen/detector.fab
+++ b/fons/rivus/codegen/detector.fab
@@ -13,7 +13,7 @@
 
 ex "../ast/positio" importa Locus
 ex "../ast/sententia" importa Sententia
-ex "../ast/expressia" importa Expressia, ObiectumProprietas
+ex "../ast/expressia" importa Expressia, ObiectumProprietas, LambdaCorpus
 
 # =============================================================================
 # FEATURE KEYS
@@ -286,7 +286,7 @@ genus FeatureDetector {
 
                 # Visit function body
                 si nonnihil f.corpus {
-                    ego.visitSententia(f.corpus qua Sententia)
+                    ego.visitSententia(f.corpus)
                 }
             }
 
@@ -368,8 +368,14 @@ genus FeatureDetector {
             }
 
             casu LambdaExpressia ut l {
-                # Lambda corpus is ignotum type - skip descending
-                # Feature detection in lambda bodies would require runtime type checks
+                discerne l.corpus {
+                    casu Massa ut m {
+                        ego.visitSententia(m.valor)
+                    }
+                    casu Expressia ut e {
+                        ego.visitExpressia(e.valor)
+                    }
+                }
             }
 
             casu _ {

--- a/fons/rivus/codegen/go/expressia/index.fab
+++ b/fons/rivus/codegen/go/expressia/index.fab
@@ -2,7 +2,7 @@
 #
 # Routes expression AST nodes to their specific generators.
 
-ex "../../../ast/expressia" importa Expressia, LitteraGenus, ObiectumProprietas, LambdaParametrum
+ex "../../../ast/expressia" importa Expressia, LitteraGenus, ObiectumProprietas, LambdaParametrum, LambdaCorpus
 ex "../../../ast/sententia" importa Sententia, VariaGenus
 ex "../../../ast/typus" importa TypusAnnotatio
 ex "../nucleus" importa GoGenerator
@@ -178,21 +178,27 @@ functio genExpressia(Expressia expr, GoGenerator g) -> textus {
                 }
             }
 
-            fixum massa = e.corpus qua Sententia
-            discerne massa {
-                casu MassaSententia ut m {
-                    g.intraProfundum()
-                    fixum body = genLambdaMassa(m.corpus, g)
-                    g.exiProfundum()
-                    si body == "" {
-                        redde scriptum("func(§) interface{} { }", params.coniunge(", "))
+            discerne e.corpus {
+                casu Massa ut m {
+                    discerne m.valor {
+                        casu MassaSententia ut body {
+                            g.intraProfundum()
+                            fixum rendered = genLambdaMassa(body.corpus, g)
+                            g.exiProfundum()
+                            si rendered == "" {
+                                redde scriptum("func(§) interface{} { }", params.coniunge(", "))
+                            }
+                            redde scriptum("func(§) interface{} {\n§\n§}", params.coniunge(", "), rendered, g.ind())
+                        }
+                        casu _ { }
                     }
-                    redde scriptum("func(§) interface{} {\n§\n§}", params.coniunge(", "), body, g.ind())
                 }
-                casu _ { }
+                casu Expressia ut expr {
+                    redde scriptum("func(§) interface{} { return § }", params.coniunge(", "), genExpressia(expr.valor, g))
+                }
             }
 
-            redde scriptum("func(§) interface{} { return § }", params.coniunge(", "), genExpressia(e.corpus qua Expressia, g))
+            redde scriptum("func(§) interface{} { return § }", params.coniunge(", "), genExpressia(finge Littera { locus: e.locus, species: LitteraGenus.Nihil, crudus: "nihil" } qua Expressia, g))
         }
 
         # New instance creation

--- a/fons/rivus/codegen/go/index.fab
+++ b/fons/rivus/codegen/go/index.fab
@@ -27,7 +27,7 @@ functio generateGo(lista<Sententia> corpus) -> textus {
             # Entry points - inline their body statements into func main
             casu IncipitSententia ut s {
                 si nonnihil s.corpus {
-                    mainSententiae.adde(s.corpus qua Sententia)
+                    mainSententiae.adde(s.corpus)
                 }
                 si nonnihil s.ergo {
                     mainSententiae.adde(s.ergo qua Sententia)
@@ -36,7 +36,7 @@ functio generateGo(lista<Sententia> corpus) -> textus {
 
             casu IncipietSententia ut s {
                 si nonnihil s.corpus {
-                    mainSententiae.adde(s.corpus qua Sententia)
+                    mainSententiae.adde(s.corpus)
                 }
                 si nonnihil s.ergo {
                     mainSententiae.adde(s.ergo qua Sententia)

--- a/fons/rivus/codegen/go/sententia/functio.fab
+++ b/fons/rivus/codegen/go/sententia/functio.fab
@@ -114,7 +114,7 @@ functio genFunctio(textus nomen, ignotum generaParametra, lista<Parametrum> para
         g.errataTypusReditus = errataType
 
         g.intraProfundum()
-        fixum body = genSententia(corpus qua Sententia, g)
+        fixum body = genSententia(corpus, g)
         g.exiProfundum()
 
         g.inErrata = prevInErrata

--- a/fons/rivus/codegen/go/sententia/genus.fab
+++ b/fons/rivus/codegen/go/sententia/genus.fab
@@ -12,7 +12,7 @@ ex "./index" importa genSententia
 ex "./functio" importa genParametrum
 
 @ publica
-functio genGenus(textus nomen, ignotum generaParametra, ignotum extendit, ignotum implet, bivalens abstractum, lista<CampusDeclaratio> campi, ignotum structor, lista<Sententia> methodi, ignotum visibilitas, GoGenerator g) -> textus {
+functio genGenus(textus nomen, ignotum generaParametra, ignotum extendit, ignotum implet, bivalens abstractum, lista<CampusDeclaratio> campi, ignotum structor, lista<FunctioDeclaratio> methodi, ignotum visibilitas, GoGenerator g) -> textus {
     # NOTE: Go has no class inheritance; extendit/implet/structor are ignored here.
     varia typeName = nomen
     si nonnihil visibilitas {
@@ -52,7 +52,7 @@ functio genGenus(textus nomen, ignotum generaParametra, ignotum extendit, ignotu
 
     ex methodi pro methodus {
         lines.adde("")
-        lines.adde(genGenusMethod(typeName, methodus, g))
+        lines.adde(genGenusMethod(typeName, methodus qua Sententia, g))
     }
 
     redde lines.coniunge("\n")
@@ -151,7 +151,7 @@ functio genGenusMethod(textus typeName, Sententia methodus, GoGenerator g) -> te
             g.errataTypusReditus = errataType
 
             g.intraProfundum()
-            fixum body = genSententia(f.corpus qua Sententia, g)
+            fixum body = genSententia(f.corpus, g)
             g.exiProfundum()
 
             g.inErrata = prevInErrata

--- a/fons/rivus/codegen/go/sententia/incipit.fab
+++ b/fons/rivus/codegen/go/sententia/incipit.fab
@@ -22,14 +22,14 @@ functio genIncipit(ignotum corpus, ignotum ergo, GoGenerator g) -> textus {
     # Check corpus first (simple incipit { ... })
     si nonnihil corpus {
         g.intraProfundum()
-        body = genSententia(corpus qua Sententia, g)
+        body = genSententia(corpus, g)
         g.exiProfundum()
     }
 
     # Then check ergo (incipit ergo ... { ... })
     si nonnihil ergo {
         g.intraProfundum()
-        fixum ergoBody = genSententia(ergo qua Sententia, g)
+        fixum ergoBody = genSententia(ergo, g)
         g.exiProfundum()
         si body != "" {
             body = scriptum("§\n§", body, ergoBody)

--- a/fons/rivus/codegen/go/sententia/index.fab
+++ b/fons/rivus/codegen/go/sententia/index.fab
@@ -97,7 +97,7 @@ functio genSententia(Sententia stmt, GoGenerator g) -> textus {
         casu CuraSententia ut s {
             # For Go, cura...fit blocks become just the body statements
             # Resource cleanup is handled by Go's GC or defer patterns
-            redde genSententia(s.corpus qua Sententia, g)
+            redde genSententia(s.corpus, g)
         }
 
         # Control flow
@@ -106,15 +106,15 @@ functio genSententia(Sententia stmt, GoGenerator g) -> textus {
         }
 
         casu DumSententia ut s {
-            redde genDum(s.condicio qua Expressia, s.corpus qua Sententia, g)
+            redde genDum(s.condicio qua Expressia, s.corpus, g)
         }
 
         casu IteratioSententia ut s {
-            redde genIteratio(s.species qua IteratioGenus, s.variabilis qua textus, s.iterabile qua Expressia, s.corpus qua Sententia, g)
+            redde genIteratio(s.species qua IteratioGenus, s.variabilis qua textus, s.iterabile qua Expressia, s.corpus, g)
         }
 
         casu FacSententia ut s {
-            redde genFac(s.corpus qua Sententia, s.condicio, g)
+            redde genFac(s.corpus, s.condicio, g)
         }
 
         casu EligeSententia ut s {

--- a/fons/rivus/codegen/ts/expressia/index.fab
+++ b/fons/rivus/codegen/ts/expressia/index.fab
@@ -2,7 +2,7 @@
 #
 # Routes expression AST nodes to their specific generators.
 
-ex "../../../ast/expressia" importa Expressia, LitteraGenus, ObiectumProprietas, LambdaParametrum, MorphologiaInvocatio
+ex "../../../ast/expressia" importa Expressia, LitteraGenus, ObiectumProprietas, LambdaParametrum, MorphologiaInvocatio, LambdaCorpus
 ex "../../../ast/expressia" importa AbFiltrum, CatenaGradus
 ex "../../../ast/sententia" importa Sententia, VariaGenus
 ex "../../../ast/typus" importa TypusAnnotatio, TypusParametrum
@@ -295,19 +295,24 @@ functio genExpressia(Expressia expr, TsGenerator g) -> textus {
         }
 
         casu PraefixumExpressia ut e {
-            # Compile-time evaluation - in TS, wrap in IIFE for block form.
-            fixum corpus = e.corpus qua Sententia
-            discerne corpus {
-                casu MassaSententia ut m {
-                    g.intraProfundum()
-                    fixum body = genPraefixumMassa(m.corpus, g)
-                    g.exiProfundum()
-                    redde scriptum("(() => {\n§\n§})()", body, g.ind())
+            discerne e.corpus {
+                casu Massa ut m {
+                    discerne m.valor {
+                        casu MassaSententia ut body {
+                            g.intraProfundum()
+                            fixum rendered = genPraefixumMassa(body.corpus, g)
+                            g.exiProfundum()
+                            redde scriptum("(() => {\n§\n§})()", rendered, g.ind())
+                        }
+                        casu _ { }
+                    }
                 }
-                casu _ { }
+                casu Expressia ut expr {
+                    redde scriptum("(§)", genExpressia(expr.valor, g))
+                }
             }
             # Fallback: expression form.
-            redde scriptum("(§)", genExpressia(e.corpus qua Expressia, g))
+            redde scriptum("(§)", genExpressia(finge Littera { locus: e.locus, species: LitteraGenus.Nihil, crudus: "nihil" } qua Expressia, g))
         }
 
         # Calls and member access
@@ -514,20 +519,26 @@ functio genExpressia(Expressia expr, TsGenerator g) -> textus {
             si nonnihil e.typusReditus {
                 retType = scriptum(": §", genTypus(e.typusReditus qua TypusAnnotatio, g))
             }
-            fixum massa = e.corpus qua Sententia
-            discerne massa {
-                casu MassaSententia ut m {
-                    g.intraProfundum()
-                    fixum body = genPraefixumMassa(m.corpus, g)
-                    g.exiProfundum()
-                    si body == "" {
-                        redde scriptum("(§)§ => {}", params.coniunge(", "), retType)
+            discerne e.corpus {
+                casu Massa ut m {
+                    discerne m.valor {
+                        casu MassaSententia ut body {
+                            g.intraProfundum()
+                            fixum rendered = genPraefixumMassa(body.corpus, g)
+                            g.exiProfundum()
+                            si rendered == "" {
+                                redde scriptum("(§)§ => {}", params.coniunge(", "), retType)
+                            }
+                            redde scriptum("(§)§ => {\n§\n§}", params.coniunge(", "), retType, rendered, g.ind())
+                        }
+                        casu _ { }
                     }
-                    redde scriptum("(§)§ => {\n§\n§}", params.coniunge(", "), retType, body, g.ind())
                 }
-                casu _ { }
+                casu Expressia ut expr {
+                    redde scriptum("(§)§ => §", params.coniunge(", "), retType, genExpressia(expr.valor, g))
+                }
             }
-            redde scriptum("(§)§ => §", params.coniunge(", "), retType, genExpressia(e.corpus qua Expressia, g))
+            redde scriptum("(§)§ => §", params.coniunge(", "), retType, genExpressia(finge Littera { locus: e.locus, species: LitteraGenus.Nihil, crudus: "nihil" } qua Expressia, g))
         }
 
         # Discretio construction

--- a/fons/rivus/codegen/ts/sententia/functio.fab
+++ b/fons/rivus/codegen/ts/sententia/functio.fab
@@ -216,7 +216,7 @@ functio genFunctio(textus nomen, ignotum generaParametra, lista<Parametrum> para
         }
 
         g.intraProfundum()
-        varia body = genSententia(corpus qua Sententia, g)
+        varia body = genSententia(corpus, g)
 
         # fiunt/fient always end with done()
         si g.inFiunt aut g.inFient {

--- a/fons/rivus/codegen/ts/sententia/genus.fab
+++ b/fons/rivus/codegen/ts/sententia/genus.fab
@@ -23,7 +23,7 @@ ex "./index" importa genSententia
 ex "../typus" importa genTypus
 
 @ publica
-functio genGenus(textus nomen, ignotum generaParametra, ignotum extendit, ignotum implet, bivalens abstractum, lista<CampusDeclaratio> campi, ignotum structor, lista<Sententia> methodi, ignotum visibilitas, TsGenerator g) -> textus {
+functio genGenus(textus nomen, ignotum generaParametra, ignotum extendit, ignotum implet, bivalens abstractum, lista<CampusDeclaratio> campi, ignotum structor, lista<FunctioDeclaratio> methodi, ignotum visibilitas, TsGenerator g) -> textus {
     varia result = g.ind()
 
     # Determine class visibility for field inheritance
@@ -77,20 +77,12 @@ functio genGenus(textus nomen, ignotum generaParametra, ignotum extendit, ignotu
     }
 
     # Split creo method from other methods
-    varia creo = nihil qua Sententia?
-    varia ceteri = [] innatum lista<Sententia>
+    varia creo = nihil qua FunctioDeclaratio?
+    varia ceteri = [] innatum lista<FunctioDeclaratio>
     ex methodi pro m {
-        varia estCreo = falsum
-        discerne m {
-            casu FunctioDeclaratio ut f {
-                si f.structor {
-                    creo = f qua Sententia
-                    estCreo = verum
-                }
-            }
-            ceterum { }
-        }
-        si non estCreo {
+        si m.structor {
+            creo = m
+        } secus {
             ceteri.adde(m)
         }
     }
@@ -152,7 +144,7 @@ functio genCreoMethod(Sententia creo, TsGenerator g) -> textus {
             varia body = "{}"
             si nonnihil f.corpus {
                 g.intraProfundum()
-                fixum content = genSententia(f.corpus qua Sententia, g)
+                fixum content = genSententia(f.corpus, g)
                 g.exiProfundum()
                 body = scriptum("{\n§\n§}", content, g.ind())
             }

--- a/fons/rivus/codegen/ts/sententia/incipit.fab
+++ b/fons/rivus/codegen/ts/sententia/incipit.fab
@@ -14,14 +14,14 @@ ex "./index" importa genSententia
 @ publica
 functio genIncipit(ignotum corpus, ignotum ergo, TsGenerator g) -> textus {
     si nonnihil corpus {
-        varia result = genSententia(corpus qua Sententia, g)
+        varia result = genSententia(corpus, g)
         si nonnihil ergo {
-            result = scriptum("§\n§", result, genSententia(ergo qua Sententia, g))
+            result = scriptum("§\n§", result, genSententia(ergo, g))
         }
         redde result
     }
     si nonnihil ergo {
-        redde genSententia(ergo qua Sententia, g)
+        redde genSententia(ergo, g)
     }
     redde ""
 }
@@ -31,14 +31,14 @@ functio genIncipiet(ignotum corpus, ignotum ergo, TsGenerator g) -> textus {
     g.intraProfundum()
     varia body = ""
     si nonnihil corpus {
-        body = genSententia(corpus qua Sententia, g)
+        body = genSententia(corpus, g)
     }
     g.exiProfundum()
 
     varia result = scriptum("§(async () => {\n§\n§})();", g.ind(), body, g.ind())
 
     si nonnihil ergo {
-        result = scriptum("§\n§", result, genSententia(ergo qua Sententia, g))
+        result = scriptum("§\n§", result, genSententia(ergo, g))
     }
 
     redde result

--- a/fons/rivus/codegen/ts/sententia/index.fab
+++ b/fons/rivus/codegen/ts/sententia/index.fab
@@ -89,7 +89,7 @@ functio genSententiaContent(Sententia stmt, TsGenerator g) -> textus {
 
         # Type declarations
         casu GenusDeclaratio ut s {
-            redde genGenus(s.nomen qua textus, s.generaParametra, s.extendit, s.implet, s.abstractum qua bivalens, s.campi qua lista<CampusDeclaratio>, s.structor, s.methodi qua lista<Sententia>, s.visibilitas, g)
+            redde genGenus(s.nomen qua textus, s.generaParametra, s.extendit, s.implet, s.abstractum qua bivalens, s.campi qua lista<CampusDeclaratio>, s.structor, s.methodi, s.visibilitas, g)
         }
 
         casu PactumDeclaratio ut s {
@@ -114,15 +114,15 @@ functio genSententiaContent(Sententia stmt, TsGenerator g) -> textus {
         }
 
         casu DumSententia ut s {
-            redde genDum(s.condicio, s.corpus qua Sententia, s.cape, g)
+            redde genDum(s.condicio, s.corpus, s.cape, g)
         }
 
         casu IteratioSententia ut s {
-            redde genIteratio(s.species qua IteratioGenus, s.variabilis qua textus, s.iterabile, s.corpus qua Sententia, s.asynca qua bivalens, s.cape, g)
+            redde genIteratio(s.species qua IteratioGenus, s.variabilis qua textus, s.iterabile, s.corpus, s.asynca qua bivalens, s.cape, g)
         }
 
         casu InSententia ut s {
-            redde genIn(s.obiectum, s.corpus qua Sententia, g)
+            redde genIn(s.obiectum, s.corpus, g)
         }
 
         casu EligeSententia ut s {
@@ -139,7 +139,7 @@ functio genSententiaContent(Sententia stmt, TsGenerator g) -> textus {
 
         # Error handling
         casu TemptaSententia ut s {
-            redde genTempta(s.corpus qua Sententia, s.cape, s.demum, g)
+            redde genTempta(s.corpus, s.cape, s.demum, g)
         }
 
         casu IaceSententia ut s {
@@ -147,7 +147,7 @@ functio genSententiaContent(Sententia stmt, TsGenerator g) -> textus {
         }
 
         casu FacSententia ut s {
-            redde genFac(s.corpus qua Sententia, s.condicio, s.cape, g)
+            redde genFac(s.corpus, s.condicio, s.cape, g)
         }
 
         casu AdfirmaSententia ut s {
@@ -184,7 +184,7 @@ functio genSententiaContent(Sententia stmt, TsGenerator g) -> textus {
         }
 
         casu CuraSententia ut s {
-            redde genCura(s.curatorSpecies, s.res, s.vinculum qua textus, s.corpus qua Sententia, s.asynca qua bivalens, s.cape, g)
+            redde genCura(s.curatorSpecies, s.res, s.vinculum qua textus, s.corpus, s.asynca qua bivalens, s.cape, g)
         }
 
         casu AdSententia {
@@ -197,11 +197,11 @@ functio genSententiaContent(Sententia stmt, TsGenerator g) -> textus {
         }
 
         casu ProbaSententia ut s {
-            redde genProba(s.nomen qua textus, s.modificator, s.ratioModificatoris, s.corpus qua Sententia, g)
+            redde genProba(s.nomen qua textus, s.modificator, s.ratioModificatoris, s.corpus, g)
         }
 
         casu PraeparaMassa ut s {
-            redde genPraepara(s.tempus qua PraeparaTempus, s.asynca qua bivalens, s.omnia qua bivalens, s.corpus qua Sententia, g)
+            redde genPraepara(s.tempus qua PraeparaTempus, s.asynca qua bivalens, s.omnia qua bivalens, s.corpus, g)
         }
     }
 

--- a/fons/rivus/parser/expressia/primaria.fab
+++ b/fons/rivus/parser/expressia/primaria.fab
@@ -30,7 +30,7 @@
 
 ex "../resolvitor" importa Resolvitor
 ex "../../ast/positio" importa Locus
-ex "../../ast/expressia" importa Expressia, LitteraGenus, ObiectumProprietas, LambdaParametrum
+ex "../../ast/expressia" importa Expressia, LitteraGenus, ObiectumProprietas, LambdaParametrum, LambdaCorpus
 ex "../../ast/expressia" importa AbFiltrum, CatenaGradus
 ex "../../ast/typus" importa TypusAnnotatio
 ex "../../ast/lexema" importa SymbolumGenus
@@ -574,14 +574,14 @@ functio parseLambdaExpressia(Resolvitor r) -> Expressia {
     }
 
     # Body: ':' expression or blockStmt
-    varia corpus = nihil qua ignotum?
+    varia corpus = nihil qua LambdaCorpus?
     si p.congruet(SymbolumGenus.Colon) {
-        corpus = r.expressia()
+        corpus = finge Expressia { valor: r.expressia() } qua LambdaCorpus
     } sin p.proba(SymbolumGenus.UncusSin) {
-        corpus = r.massa()
+        corpus = finge Massa { valor: r.massa() } qua LambdaCorpus
     } secus {
         p.expecta(SymbolumGenus.Colon, ParserErrorCodice.ExpectaturColon)
-        corpus = r.expressia()
+        corpus = finge Expressia { valor: r.expressia() } qua LambdaCorpus
     }
 
     redde finge LambdaExpressia {
@@ -673,23 +673,25 @@ functio parsePraefixumExpressia(Resolvitor r) -> Expressia {
 
     p.expectaVerbum("praefixum", ParserErrorCodice.ExpectaturExpressia)
 
-    varia corpus = nihil qua ignotum?
+    varia corpus = nihil qua LambdaCorpus?
 
     si p.proba(SymbolumGenus.UncusSin) {
         # WHY: Block form is allowed in grammar, but AST expects an expression.
         fixum massa = r.massa()
-        corpus = massa
+        corpus = finge Massa { valor: massa } qua LambdaCorpus
     } sin p.congruet(SymbolumGenus.ParensSin) {
         fixum expr = r.expressia()
         p.expecta(SymbolumGenus.ParensDex, ParserErrorCodice.ExpectaturParensDex)
-        corpus = expr
+        corpus = finge Expressia { valor: expr } qua LambdaCorpus
     } secus {
         p.renuncia(ParserErrorCodice.ExpectaturUncusVelParens, scriptum("got '§'", p.specta(0).valor))
-        corpus = finge Littera {
-            locus: locus,
-            species: LitteraGenus.Nihil,
-            crudus: "nihil"
-        } qua Expressia
+        corpus = finge Expressia {
+            valor: finge Littera {
+                locus: locus,
+                species: LitteraGenus.Nihil,
+                crudus: "nihil"
+            } qua Expressia
+        } qua LambdaCorpus
     }
 
     redde finge PraefixumExpressia {

--- a/fons/rivus/parser/sententia/declara.fab
+++ b/fons/rivus/parser/sententia/declara.fab
@@ -247,8 +247,8 @@ functio parseGenusDeclaratio(Resolvitor r, bivalens abstractum) -> Sententia {
     p.expecta(SymbolumGenus.UncusSin, ParserErrorCodice.ExpectaturUncusSin)
 
     varia campi = [] innatum lista<CampusDeclaratio>
-    varia methodi = [] innatum lista<Sententia>
-    varia structor = nihil qua Sententia?
+    varia methodi = [] innatum lista<FunctioDeclaratio>
+    varia structor = nihil qua FunctioDeclaratio?
 
     dum non p.proba(SymbolumGenus.UncusDex) et non p.estFinis() {
         # Parse annotations for visibility/abstract/morphologia
@@ -336,7 +336,7 @@ functio parseGenusDeclaratio(Resolvitor r, bivalens abstractum) -> Sententia {
                 visibilitas = Visibilitas.Privata
             }
 
-            methodi.adde(finge FunctioDeclaratio {
+            fixum methodus = {
                 locus: methodLocus,
                 nomen: methodNomen,
                 generaParametra: nihil,
@@ -352,7 +352,12 @@ functio parseGenusDeclaratio(Resolvitor r, bivalens abstractum) -> Sententia {
                 reddeVerbum: nihil,
                 morphologia: morphologiaEx(annotationes),
                 modificatores: modificatores
-            } qua Sententia)
+            } qua FunctioDeclaratio
+
+            si estStructor {
+                structor = methodus
+            }
+            methodi.adde(methodus)
         } secus {
             # Field: type name or name: default
             fixum campusLocus = p.locusActualis()

--- a/fons/rivus/semantic/expressia/alia.fab
+++ b/fons/rivus/semantic/expressia/alia.fab
@@ -8,7 +8,7 @@ ex "../typi" importa functioTypus, usitatumTypus, genericumTypus
 ex "../scopus" importa ScopusSpecies, SymbolumSpecies
 ex "../errores" importa cedeOutsideAsyncError
 ex "../sententia/declara" importa resolveTypusAnnotatio
-ex "../../ast/expressia" importa Expressia
+ex "../../ast/expressia" importa Expressia, LambdaCorpus
 ex "../../ast/sententia" importa Sententia
 ex "../../ast/typus" importa TypusAnnotatio
 
@@ -47,31 +47,33 @@ functio resolveLambda(Resolvitor r, Expressia lambdaExpr) -> SemanticTypus {
 
             # Resolve body (expression or block)
             varia reditusTypus = VACUUM
-            fixum massa = l.corpus qua Sententia
-            varia estMassa = falsum
-            discerne massa {
-                casu MassaSententia ut m {
-                    estMassa = verum
-                    r.sententia(massa)
-                    si m.corpus.longitudo() > 0 {
-                        fixum ult = m.corpus[m.corpus.longitudo() - 1]
-                        discerne ult {
-                            casu ReddeSententia ut s {
-                                si nonnihil s.valor {
-                                    reditusTypus = r.expressia(s.valor qua Expressia)
+            discerne l.corpus {
+                casu Massa ut m {
+                    r.sententia(m.valor)
+                    discerne m.valor {
+                        casu MassaSententia ut body {
+                            fixum corpusLista = body.corpus qua lista<Sententia>
+                            si corpusLista.longitudo() > 0 {
+                                fixum ult = corpusLista[corpusLista.longitudo() - 1]
+                                discerne ult {
+                                    casu ReddeSententia ut s {
+                                        si nonnihil s.valor {
+                                            reditusTypus = r.expressia(s.valor qua Expressia)
+                                        }
+                                    }
+                                    casu ExpressiaSententia ut s {
+                                        reditusTypus = r.expressia(s.expressia)
+                                    }
+                                    casu _ { }
                                 }
                             }
-                            casu ExpressiaSententia ut s {
-                                reditusTypus = r.expressia(s.expressia)
-                            }
-                            casu _ { }
                         }
+                        casu _ { }
                     }
                 }
-                casu _ { }
-            }
-            si non estMassa {
-                reditusTypus = r.expressia(l.corpus qua Expressia)
+                casu Expressia ut e {
+                    reditusTypus = r.expressia(e.valor)
+                }
             }
 
             # Exit function scope

--- a/fons/rivus/semantic/index.fab
+++ b/fons/rivus/semantic/index.fab
@@ -121,18 +121,13 @@ functio predeclare(Resolvitor r, Sententia stmt) -> vacuum {
                 locus: g.locus
             } qua Symbolum)
 
-            ex g.methodi pro methodus {
-                discerne methodus {
-                    casu FunctioDeclaratio ut f {
-                        si nonnihil f.morphologia {
-                            fixum parsed = parseMethodum(f.nomen)
-                            si nonnihil parsed {
-                                fixum nota = f.morphologia qua MorphologiaDeclaratio
-                                a.addeMorphologiam(g.nomen, parsed.radix, nota.formae)
-                            }
-                        }
+            ex g.methodi pro f {
+                si nonnihil f.morphologia {
+                    fixum parsed = parseMethodum(f.nomen)
+                    si nonnihil parsed {
+                        fixum nota = f.morphologia qua MorphologiaDeclaratio
+                        a.addeMorphologiam(g.nomen, parsed.radix, nota.formae)
                     }
-                    casu _ { }
                 }
             }
         }

--- a/fons/rivus/semantic/sententia/declara.fab
+++ b/fons/rivus/semantic/sententia/declara.fab
@@ -266,8 +266,9 @@ functio analyzeFunctioDeclaratio(Resolvitor r, Sententia functioStmt) -> vacuum 
                     i += 1
                 }
 
-                # Analyze body
-                r.sententia(f.corpus qua Sententia)
+            # Analyze body
+            r.sententia(f.corpus)
+
 
                 # Exit scope and restore context
                 a.exiScopum()
@@ -308,36 +309,31 @@ functio analyzeGenusDeclaratio(Resolvitor r, Sententia genusStmt) -> vacuum {
             varia methodi = {} innatum tabula<textus, SemanticTypus>
             varia methodiStatici = {} innatum tabula<textus, SemanticTypus>
 
-            ex g.methodi pro methodusStmt {
-                discerne methodusStmt {
-                    casu FunctioDeclaratio ut m {
-                        validateFunctioModificatores(r, m.modificatores, verum)
+            ex g.methodi pro m {
+                validateFunctioModificatores(r, m.modificatores, verum)
 
-                        # Build parameter types
-                        varia paramTypi = [] innatum lista<SemanticTypus>
-                        ex m.parametra pro param {
-                            si nonnihil param.typus {
-                                paramTypi.adde(resolveTypusAnnotatio(r, param.typus qua TypusAnnotatio))
-                            } secus {
-                                paramTypi.adde(IGNOTUM)
-                            }
-                        }
-
-                        # Resolve return type
-                        varia reditusTypus = VACUUM qua SemanticTypus
-                        si nonnihil m.typusReditus {
-                            reditusTypus = resolveTypusAnnotatio(r, m.typusReditus qua TypusAnnotatio)
-                        }
-
-                        # Build function type
-                        fixum fnTypus = functioTypus(paramTypi, reditusTypus, m.asynca, falsum)
-
-                        # WHY: FunctioDeclaratio doesn't have staticum field (AST limitation).
-                        # All methods are treated as instance methods for now.
-                        methodi[m.nomen] = fnTypus
+                # Build parameter types
+                varia paramTypi = [] innatum lista<SemanticTypus>
+                ex m.parametra pro param {
+                    si nonnihil param.typus {
+                        paramTypi.adde(resolveTypusAnnotatio(r, param.typus qua TypusAnnotatio))
+                    } secus {
+                        paramTypi.adde(IGNOTUM)
                     }
-                    casu _ { }
                 }
+
+                # Resolve return type
+                varia reditusTypus = VACUUM qua SemanticTypus
+                si nonnihil m.typusReditus {
+                    reditusTypus = resolveTypusAnnotatio(r, m.typusReditus qua TypusAnnotatio)
+                }
+
+                # Build function type
+                fixum fnTypus = functioTypus(paramTypi, reditusTypus, m.asynca, falsum)
+
+                # WHY: FunctioDeclaratio doesn't have staticum field (AST limitation).
+                # All methods are treated as instance methods for now.
+                methodi[m.nomen] = fnTypus
             }
 
             # Create genus type with populated maps
@@ -357,61 +353,57 @@ functio analyzeGenusDeclaratio(Resolvitor r, Sententia genusStmt) -> vacuum {
             fixum prevGenusNomen = a.currentGenusNomen
             a.currentGenusNomen = g.nomen
 
-            ex g.methodi pro methodusStmt {
-                discerne methodusStmt {
-                    casu FunctioDeclaratio ut m {
-                        # Analyze method body with genus context
-                        si nonnihil m.corpus {
-                            # Get method signature from our built maps
-                            varia methodTypus = IGNOTUM
-                            si nonnihil methodi[m.nomen] {
-                                methodTypus = methodi[m.nomen]
-                            }
+            ex g.methodi pro m {
+                # Analyze method body with genus context
+                si nonnihil m.corpus {
+                    # Get method signature from our built maps
+                    varia methodTypus = IGNOTUM
+                    si nonnihil methodi[m.nomen] {
+                        methodTypus = methodi[m.nomen]
+                    }
 
-                            # Extract function details for context
-                            varia reditusTypus = VACUUM qua SemanticTypus
-                            discerne methodTypus {
-                                casu Functio ut fn {
-                                    reditusTypus = fn.reditusTypus
-                                }
-                                casu _ { }
-                            }
+                    # Extract function details for context
+                    varia reditusTypus = VACUUM qua SemanticTypus
+                    discerne methodTypus {
+                        casu Functio ut fn {
+                            reditusTypus = fn.reditusTypus
+                        }
+                        casu _ { }
+                    }
 
-                            # Save function context
-                            fixum prevReditus = a.currentFunctioReditus
-                            fixum prevAsync = a.currentFunctioAsync
-                            fixum prevGenerator = a.currentFunctioGenerator
+                    # Save function context
+                    fixum prevReditus = a.currentFunctioReditus
+                    fixum prevAsync = a.currentFunctioAsync
+                    fixum prevGenerator = a.currentFunctioGenerator
 
-                            a.currentFunctioReditus = reditusTypus
-                            a.currentFunctioAsync = m.asynca
-                            a.currentFunctioGenerator = m.generator
+                    a.currentFunctioReditus = reditusTypus
+                    a.currentFunctioAsync = m.asynca
+                    a.currentFunctioGenerator = m.generator
 
-                            # Enter method scope
-                            a.intraScopum(ScopusSpecies.Functio)
+                    # Enter method scope
+                    a.intraScopum(ScopusSpecies.Functio)
 
-                            # Define method parameters with default types for now
-                            # TODO: Extract parameter types from function type
-                            ex m.parametra pro param {
-                                a.scopus.symbola[param.nomen] = {
-                                    nomen: param.nomen,
-                                    semanticTypus: IGNOTUM,  # TODO: Extract from methodTypus
-                                    species: SymbolumSpecies.Parametrum,
-                                    mutabilis: falsum,
-                                    locus: param.locus
-                                }
-                            }
-
-                            # Analyze method body
-                            r.sententia(m.corpus qua Sententia)
-
-                            # Exit scope and restore context
-                            a.exiScopum()
-                            a.currentFunctioReditus = prevReditus
-                            a.currentFunctioAsync = prevAsync
-                            a.currentFunctioGenerator = prevGenerator
+                    # Define method parameters with default types for now
+                    # TODO: Extract parameter types from function type
+                    ex m.parametra pro param {
+                        a.scopus.symbola[param.nomen] = {
+                            nomen: param.nomen,
+                            semanticTypus: IGNOTUM,  # TODO: Extract from methodTypus
+                            species: SymbolumSpecies.Parametrum,
+                            mutabilis: falsum,
+                            locus: param.locus
                         }
                     }
-                    casu _ { }
+
+                            # Analyze method body
+                            r.sententia(m.corpus)
+
+
+                    # Exit scope and restore context
+                    a.exiScopum()
+                    a.currentFunctioReditus = prevReditus
+                    a.currentFunctioAsync = prevAsync
+                    a.currentFunctioGenerator = prevGenerator
                 }
             }
 


### PR DESCRIPTION
## Summary
- replace ignotum lambda/praefixum corpus with a dedicated LambdaCorpus union
- tighten genus method/structor types and update parser/semantic passes accordingly
- adjust TS/Go codegen to handle LambdaCorpus and narrower block bodies

## Testing
- bun run build:rivus (fails at TypeScript typecheck; existing repo errors in coreutils/fons/faber)