### PR TITLE
feat(radix-rs): enforce Unicode XID identifiers and NFC interning

### DIFF
--- a/fons/radix-rs/Cargo.lock
+++ b/fons/radix-rs/Cargo.lock
@@ -149,6 +149,8 @@ dependencies = [
  "pretty_assertions",
  "rustc-hash",
  "thiserror",
+ "unicode-ident",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -221,10 +223,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-width"

--- a/fons/radix-rs/Cargo.toml
+++ b/fons/radix-rs/Cargo.toml
@@ -9,6 +9,8 @@ license = "MIT"
 ariadne = "0.4"
 thiserror = "2"
 rustc-hash = "2"
+unicode-ident = "1"
+unicode-normalization = "0.1"
 
 [dev-dependencies]
 insta = "1"

--- a/fons/radix-rs/src/lexer/scan.rs
+++ b/fons/radix-rs/src/lexer/scan.rs
@@ -4,6 +4,7 @@ use super::cursor::Cursor;
 use super::token::{Span, Symbol, Token, TokenKind};
 use super::{LexError, LexErrorKind, LexResult};
 use rustc_hash::FxHashMap;
+use unicode_normalization::UnicodeNormalization;
 
 /// Lexer mode - determines which keyword table is active
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -35,12 +36,13 @@ impl Interner {
     }
 
     pub fn intern(&mut self, s: &str) -> Symbol {
-        if let Some(&sym) = self.map.get(s) {
+        let normalized: String = s.nfc().collect();
+        if let Some(&sym) = self.map.get(&normalized) {
             return sym;
         }
         let sym = Symbol(self.strings.len() as u32);
-        self.strings.push(s.to_owned());
-        self.map.insert(s.to_owned(), sym);
+        self.strings.push(normalized.clone());
+        self.map.insert(normalized, sym);
         sym
     }
 
@@ -603,12 +605,16 @@ impl<'a> Lexer<'a> {
 }
 
 fn is_ident_start(c: char) -> bool {
-    c.is_alphabetic() || c == '_'
+    unicode_ident::is_xid_start(c) || c == '_'
 }
 
 fn is_ident_continue(c: char) -> bool {
-    c.is_alphanumeric() || c == '_'
+    unicode_ident::is_xid_continue(c) || c == '_'
 }
+
+#[cfg(test)]
+#[path = "scan_test.rs"]
+mod tests;
 
 /// Normal mode keywords - statements and expressions
 fn keyword_or_ident(text: &str, interner: &mut Interner) -> TokenKind {

--- a/fons/radix-rs/src/lexer/scan_test.rs
+++ b/fons/radix-rs/src/lexer/scan_test.rs
@@ -1,0 +1,47 @@
+use super::Interner;
+use crate::lexer::{lex, LexErrorKind, TokenKind};
+
+#[test]
+fn lexes_unicode_identifiers() {
+    let result = lex("fixum 变量 = 1");
+    assert!(result.errors.is_empty());
+    assert!(result
+        .tokens
+        .iter()
+        .any(|token| matches!(token.kind, TokenKind::Ident(_))));
+}
+
+#[test]
+fn rejects_non_xid_identifier_start() {
+    let result = lex("\u{0301}abc");
+    assert!(!result.errors.is_empty());
+    assert!(result
+        .errors
+        .iter()
+        .any(|err| err.kind == LexErrorKind::UnexpectedCharacter));
+}
+
+#[test]
+fn normalizes_interned_identifiers_to_nfc() {
+    let mut interner = Interner::new();
+    let composed = interner.intern("café");
+    let decomposed = interner.intern("cafe\u{301}");
+
+    assert_eq!(composed, decomposed);
+    assert_eq!(interner.resolve(composed), "café");
+}
+
+#[test]
+fn lexer_interns_equivalent_unicode_forms_as_one_symbol() {
+    let result = lex("fixum café = 1\nfixum cafe\u{301} = 2");
+    assert!(result.errors.is_empty());
+
+    let mut idents = result.tokens.iter().filter_map(|token| match token.kind {
+        TokenKind::Ident(sym) => Some(sym),
+        _ => None,
+    });
+
+    let first = idents.next().expect("first identifier");
+    let second = idents.next().expect("second identifier");
+    assert_eq!(first, second);
+}


### PR DESCRIPTION
## Summary
- switch lexer identifier checks from broad alphabetic/alphanumeric to strict Unicode XID rules
- normalize interned strings to NFC so equivalent composed/decomposed identifiers map to one symbol
- add lexer tests for Unicode identifiers, non-XID starts, and NFC symbol equivalence

## Verification
- cargo test (from fons/radix-rs) -> 30 passed, 0 failed

Closes #271
