### PR TITLE
feat(radix-rs): tighten ignotum semantics and unresolved type output

### DIFF
--- a/fons/radix-rs/src/codegen/faber/mod.rs
+++ b/fons/radix-rs/src/codegen/faber/mod.rs
@@ -375,7 +375,7 @@ impl FaberCodegen {
                 format!("{}<{}>", base_str, args_str.join(", "))
             }
 
-            Type::Infer(_) => "ignotum".to_owned(),
+            Type::Infer(_) => "/* unresolved */".to_owned(),
             Type::Union(_) => "unio".to_owned(),
             Type::Error => "/* error */".to_owned(),
         }

--- a/fons/radix-rs/src/codegen/faber/mod_test.rs
+++ b/fons/radix-rs/src/codegen/faber/mod_test.rs
@@ -1,9 +1,10 @@
-use super::{Codegen, DefId, FaberCodegen, Interner, Primitive, TypeTable};
+use super::{Codegen, DefId, FaberCodegen, Interner, Primitive, Type, TypeTable};
 use crate::hir::{
     HirBlock, HirExpr, HirExprKind, HirFunction, HirItem, HirItemKind, HirLiteral, HirParam, HirParamMode, HirProgram,
     HirStmt, HirStmtKind,
 };
 use crate::lexer::Span;
+use crate::semantic::InferVar;
 
 fn span() -> Span {
     Span::default()
@@ -63,4 +64,35 @@ fn emits_basic_function_and_entry() {
     assert!(output.code.contains("functio greet"));
     assert!(output.code.contains("incipit"));
     assert!(output.code.contains("redde \"salve\""));
+}
+
+#[test]
+fn renders_unresolved_infer_as_comment_marker() {
+    let mut interner = Interner::new();
+    let name = interner.intern("x");
+    let mut types = TypeTable::new();
+    let unresolved = types.intern(Type::Infer(InferVar(99)));
+
+    let program = HirProgram {
+        items: Vec::new(),
+        entry: Some(HirBlock {
+            stmts: vec![HirStmt {
+                id: crate::hir::HirId(1),
+                kind: HirStmtKind::Local(crate::hir::HirLocal {
+                    def_id: DefId(1),
+                    name,
+                    ty: Some(unresolved),
+                    init: None,
+                    mutable: false,
+                }),
+                span: span(),
+            }],
+            expr: None,
+            span: span(),
+        }),
+    };
+
+    let gen = FaberCodegen::new();
+    let output = gen.generate(&program, &types, &interner).expect("codegen");
+    assert!(output.code.contains("/* unresolved */ x"));
 }

--- a/fons/radix-rs/src/diagnostics/catalog.rs
+++ b/fons/radix-rs/src/diagnostics/catalog.rs
@@ -238,5 +238,11 @@ fn warning_spec(kind: WarningKind) -> DiagnosticSpec {
         WarningKind::UnusedMoveParam => {
             DiagnosticSpec { code: "WARN009", help: Some("change 'ex' to 'de' if ownership transfer is unnecessary") }
         }
+        WarningKind::ExplicitIgnotumAnnotation => {
+            DiagnosticSpec {
+                code: "WARN010",
+                help: Some("prefer a concrete type annotation to keep type-checking precise"),
+            }
+        }
     }
 }

--- a/fons/radix-rs/src/semantic/error.rs
+++ b/fons/radix-rs/src/semantic/error.rs
@@ -86,6 +86,7 @@ pub enum WarningKind {
     TargetNoop,
     UnusedMutRefParam,
     UnusedMoveParam,
+    ExplicitIgnotumAnnotation,
 }
 
 impl std::fmt::Display for SemanticError {

--- a/fons/radix-rs/src/semantic/mod.rs
+++ b/fons/radix-rs/src/semantic/mod.rs
@@ -16,7 +16,7 @@ mod types;
 
 pub use error::{SemanticError, SemanticErrorKind, WarningKind};
 pub use scope::{Resolver, Scope, ScopeId, ScopeKind, Symbol, SymbolKind};
-pub use types::{FuncSig, Mutability, ParamMode, ParamType, Primitive, Type, TypeId, TypeTable};
+pub use types::{FuncSig, InferVar, Mutability, ParamMode, ParamType, Primitive, Type, TypeId, TypeTable};
 
 use crate::codegen::Target;
 use crate::hir::HirProgram;

--- a/fons/radix-rs/src/semantic/passes/lint.rs
+++ b/fons/radix-rs/src/semantic/passes/lint.rs
@@ -7,7 +7,7 @@ use crate::hir::{
     HirStmt, HirStmtKind,
 };
 use crate::lexer::Span;
-use crate::semantic::{error::WarningKind, Resolver, SemanticError, SemanticErrorKind, TypeTable};
+use crate::semantic::{error::WarningKind, Primitive, Resolver, SemanticError, SemanticErrorKind, Type, TypeTable};
 use rustc_hash::FxHashSet;
 
 /// Run lint checks
@@ -138,6 +138,7 @@ impl<'a> LintContext<'a> {
                 .push((param.def_id, param.span, WarningKind::UnusedVariable));
             self.check_shadowing(param.name, param.def_id, param.span);
             self.insert_name(param.name, param.def_id);
+            self.warn_on_explicit_ignotum(param.ty, param.span);
         }
         if let Some(body) = &func.body {
             self.check_block(body, false);
@@ -181,25 +182,21 @@ impl<'a> LintContext<'a> {
     }
 
     fn check_local(&mut self, local: &HirLocal) {
+        let span = local
+            .init
+            .as_ref()
+            .map(|expr| expr.span)
+            .unwrap_or_default();
         self.defs.push((
             local.def_id,
-            local
-                .init
-                .as_ref()
-                .map(|expr| expr.span)
-                .unwrap_or_default(),
+            span,
             WarningKind::UnusedVariable,
         ));
-        self.check_shadowing(
-            local.name,
-            local.def_id,
-            local
-                .init
-                .as_ref()
-                .map(|expr| expr.span)
-                .unwrap_or_default(),
-        );
+        self.check_shadowing(local.name, local.def_id, span);
         self.insert_name(local.name, local.def_id);
+        if let Some(ty) = local.ty {
+            self.warn_on_explicit_ignotum(ty, span);
+        }
         if let Some(init) = &local.init {
             self.check_expr(init, false);
         }
@@ -321,6 +318,16 @@ impl<'a> LintContext<'a> {
 
     fn pop_scope(&mut self) {
         self.scope.pop();
+    }
+
+    fn warn_on_explicit_ignotum(&mut self, ty: crate::semantic::TypeId, span: Span) {
+        if matches!(self.types.get(ty), Type::Primitive(Primitive::Ignotum)) {
+            self.warnings.push((
+                WarningKind::ExplicitIgnotumAnnotation,
+                "explicit ignotum annotation disables precise type-checking".to_owned(),
+                span,
+            ));
+        }
     }
 }
 

--- a/fons/radix-rs/src/semantic/passes/lint_test.rs
+++ b/fons/radix-rs/src/semantic/passes/lint_test.rs
@@ -207,3 +207,34 @@ fn warns_on_unreachable_after_break() {
         .iter()
         .any(|err| err.kind == SemanticErrorKind::Warning(WarningKind::UnreachableCode)));
 }
+
+#[test]
+fn warns_on_explicit_ignotum_annotation() {
+    let mut types = TypeTable::new();
+    let ignotum = types.primitive(Primitive::Ignotum);
+    let program = HirProgram {
+        items: Vec::new(),
+        entry: Some(HirBlock {
+            stmts: vec![HirStmt {
+                id: crate::hir::HirId(1),
+                kind: HirStmtKind::Local(HirLocal {
+                    def_id: crate::hir::DefId(1),
+                    name: crate::lexer::Symbol(1),
+                    ty: Some(ignotum),
+                    init: None,
+                    mutable: false,
+                }),
+                span: span(),
+            }],
+            expr: None,
+            span: span(),
+        }),
+    };
+
+    let result = lint(&program, &Resolver::new(), &types);
+    assert!(result.is_err());
+    let errors = result.unwrap_err();
+    assert!(errors
+        .iter()
+        .any(|err| err.kind == SemanticErrorKind::Warning(WarningKind::ExplicitIgnotumAnnotation)));
+}

--- a/fons/radix-rs/src/semantic/types.rs
+++ b/fons/radix-rs/src/semantic/types.rs
@@ -104,6 +104,9 @@ impl TypeTable {
         let to_ty = self.get(to);
 
         match (from_ty, to_ty) {
+            // ignotum is an unknown sink: values can flow into it, but not out without cast/narrowing.
+            (Type::Primitive(Primitive::Ignotum), _) => false,
+
             // nil is assignable to Option<T>
             (Type::Primitive(Primitive::Nihil), Type::Option(_)) => true,
 
@@ -229,3 +232,7 @@ pub enum ParamMode {
 /// Inference variable
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct InferVar(pub u32);
+
+#[cfg(test)]
+#[path = "types_test.rs"]
+mod tests;

--- a/fons/radix-rs/src/semantic/types_test.rs
+++ b/fons/radix-rs/src/semantic/types_test.rs
@@ -1,0 +1,27 @@
+use super::{Primitive, TypeTable};
+
+#[test]
+fn allows_assigning_concrete_type_to_ignotum() {
+    let mut types = TypeTable::new();
+    let textus = types.primitive(Primitive::Textus);
+    let ignotum = types.primitive(Primitive::Ignotum);
+
+    assert!(types.assignable(textus, ignotum));
+}
+
+#[test]
+fn rejects_assigning_ignotum_to_concrete_type() {
+    let mut types = TypeTable::new();
+    let ignotum = types.primitive(Primitive::Ignotum);
+    let textus = types.primitive(Primitive::Textus);
+
+    assert!(!types.assignable(ignotum, textus));
+}
+
+#[test]
+fn still_assigns_same_type_id() {
+    let mut types = TypeTable::new();
+    let ignotum = types.primitive(Primitive::Ignotum);
+
+    assert!(types.assignable(ignotum, ignotum));
+}


### PR DESCRIPTION
## Summary
- make `ignotum` assignability behavior explicit as a one-way sink in `TypeTable::assignable`
- add type-system tests to lock `ignotum` directionality (`T -> ignotum`, not `ignotum -> T`)
- stop conflating unresolved inference with user `ignotum` in Faber codegen (`Type::Infer(_)` now renders as `/* unresolved */`)
- add codegen test for unresolved infer rendering
- add lint warning for explicit `ignotum` annotations and wire diagnostics (`WARN010`)

## Verification
- cargo test (from fons/radix-rs) -> 39 passed, 0 failed

Closes #274
